### PR TITLE
Close login window in Cordova/Android on hitting Back key

### DIFF
--- a/sdk/src/LoginUis/CordovaPopup.js
+++ b/sdk/src/LoginUis/CordovaPopup.js
@@ -45,7 +45,7 @@ exports.login = function (startUri, endUri, callback) {
 
     // iOS inAppBrowser issue requires this wrapping
     setTimeout(function () {
-        var loginWindow = window.open(startPage, "_blank", "location=no"),
+        var loginWindow = window.open(startPage, "_blank", "location=no,hardwareback=no"),
             flowHasFinished = false,
             loadEventHandler = function (evt) {
                 if (!flowHasFinished && evt.url.indexOf(endUri) === 0) {


### PR DESCRIPTION
- Currently declining permissions while logging in leads you to ead end page. Hitting back does not close the login window but instead takes you to the previous page in history. The only way to get out is is to not deny permissions.
- With this change, hitting the hardware back key will close the login window.
- 'hardwareback' has no effect on platforms other than Android
- Ideally, we would like to detect a 401 and close the login window without requiring the user to hit the back key, but there is no way to do that in InAppBrowser currently. This fix provides a good enough way to address this not so common case.
- Fixes issue https://github.com/Azure/azure-mobile-apps-js-client/issues/56 for Cordova.