### PR TITLE
Push and pull implementation

### DIFF
--- a/sdk/src/sync/MobileServiceSyncContext.js
+++ b/sdk/src/sync/MobileServiceSyncContext.js
@@ -6,6 +6,8 @@ var Validate = require('../Utilities/Validate'),
     Platform = require('Platforms/Platform'),
     createOperationTableManager = require('./operations').createOperationTableManager,
     taskRunner = require('../Utilities/taskRunner'),
+    createPullManager = require('./pull').createPullManager,
+    createPushManager = require('./push').createPushManager,
     uuid = require('node-uuid'),
     _ = require('../Utilities/Extensions');
 
@@ -23,6 +25,9 @@ function MobileServiceSyncContext(client) {
     
     var store,
         operationTableManager,
+        pullManager,
+        pushManager,
+        syncTaskRunner = taskRunner(), // Used to run push / pull tasks
         storeTaskRunner = taskRunner(); // Used to run insert / update / delete tasks on the store
 
     /**
@@ -43,6 +48,8 @@ function MobileServiceSyncContext(client) {
             return operationTableManager.initialize(localStore);
         }).then(function() {
             store = localStore; // Assigning to store after all initialization steps are complete
+            pullManager = createPullManager(client, store, storeTaskRunner, operationTableManager);
+            pushManager = createPushManager(client, store, storeTaskRunner, operationTableManager);
         });
         
     };
@@ -149,6 +156,37 @@ function MobileServiceSyncContext(client) {
                 ]);
             });
         });
+    };
+    
+    /**
+     * Pulls changes from the server tables into the local store.
+     * 
+     * @param query Query specifying which records to pull
+     * @param queryId A unique string ID for an incremental pull query OR null for a vanilla pull query.
+     * 
+     * @returns A promise that is fulfilled when all records are pulled OR is rejected if the pull fails or is cancelled.  
+     */
+    this.pull = function (query, queryId) {
+        //TODO: Implement cancel
+        //TODO: Perform push before pulling
+        return syncTaskRunner.run(function() {
+            return pullManager.pull(query, queryId);
+        });
+    };
+    
+    /**
+     * Pushes operations performed on the local store to the server tables.
+     * 
+     * Error handling is delegated to the pushHandler property of MobileServiceSyncContext instance.
+     * The pushHandler is an object with the following property:
+     * - function onRecordPushError(pushError) - this is called when an error is encountered while pushing a record to the server.
+     * 
+     * @returns A promise that is fulfilled when all pending operations are pushed OR is rejected if the push fails or is cancelled.  
+     */
+    this.push = function () { //TODO: Implement cancel
+        return syncTaskRunner.run(function() {
+            return pushManager.push(this.pushHandler);
+        }.bind(this));
     };
     
     // Unit test purposes only

--- a/sdk/src/sync/MobileServiceSyncContext.js
+++ b/sdk/src/sync/MobileServiceSyncContext.js
@@ -179,7 +179,8 @@ function MobileServiceSyncContext(client) {
      * 
      * Error handling is delegated to the pushHandler property of MobileServiceSyncContext instance.
      * The pushHandler is an object with the following property:
-     * - function onRecordPushError(pushError) - this is called when an error is encountered while pushing a record to the server.
+     * - function onConflict (serverRecord, clientRecord, pushError) - this is called when a conflict is encountered while pushing a record to the server.
+     * - function onError (pushError) - this is called when an error is encountered while pushing a record to the server.
      * 
      * @returns A promise that is fulfilled when all pending operations are pushed OR is rejected if the push fails or is cancelled.  
      */

--- a/sdk/src/sync/pull.js
+++ b/sdk/src/sync/pull.js
@@ -1,0 +1,195 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * Table pull logic implementation
+ */
+
+var Validate = require('../Utilities/Validate'),
+    Query = require('query.js').Query,
+    Platform = require('Platforms/Platform'),
+    taskRunner = require('../Utilities/taskRunner'),
+    MobileServiceTable = require('../MobileServiceTable'),
+    tableConstants = require('../constants').table,
+    _ = require('../Utilities/Extensions');
+    
+var pageSize = 50,
+    idPropertyName = tableConstants.idPropertyName,
+    sysProps = tableConstants.sysProps;
+    
+function createPullManager(client, store, storeTaskRunner, operationTableManager) {
+    // Task runner for running pull tasks. We want only one pull to run at a time. 
+    var pullTaskRunner = taskRunner(),
+        mobileServiceTable,
+        pullQuery;
+    
+    return {
+        pull: pull
+    };
+    
+    /**
+     * Pulls changes from the server tables into the local store.
+     * 
+     * @param query Query specifying which records to pull
+     * @param queryId A unique string ID for an incremental pull query OR null for a vanilla pull query.
+     * 
+     * @returns A promise that is fulfilled when all records are pulled OR is rejected if the pull fails or is cancelled.  
+     */
+    function pull(query, queryId) {
+        //TODO: support queryId
+        //TODO: page size should be configurable
+        
+        return pullTaskRunner.run(function() {
+            validateQuery(query);
+            Validate.isString(queryId); // non-null string or null - both are valid
+
+            // Make a copy of the query as we will be modifying it            
+            var components = query.getComponents();
+            pullQuery = new Query(components.table);
+            pullQuery.setComponents(components);
+
+            // Set up the query for initiating a pull and then pull all pages          
+            return setupQuery(pullQuery, queryId).then(function() {
+                return pullAllPages(pullQuery, queryId);
+            });
+        });
+    }
+    
+    // Setup the query to get started with pull
+    function setupQuery(query, queryId) {
+        return Platform.async(function(callback) {
+            
+            // Sort the results by 'updatedAt' column and fetch pageSize results
+            query.orderBy('updatedAt');
+            query.take(pageSize);
+
+            callback();
+        })();
+    }
+
+    // Pulls all pages from the server table, one page at a time.
+    function pullAllPages(query, queryId) {
+        mobileServiceTable = client.getTable(query.getComponents().table);
+        
+        // 1. Pull one page
+        // 2. Check if Pull is complete
+        // 3. If it is complete, go to 5. If not, update the query to fetch the next page.
+        // 4. Go to 1
+        // 5. DONE
+        return pullPage(query, queryId).then(function(pulledRecords) {
+            if (!isPullComplete(pulledRecords)) {
+                // update query and continue pulling the remaining pages
+                return updateQueryForNextPage(query, queryId, pulledRecords).then(function() {
+                    return pullAllPages(query, queryId);
+                });
+            }
+        });
+    }
+    
+    // Check if the pull is complete or if there are more records left to be pulled
+    function isPullComplete(pulledRecords) {
+        return pulledRecords.length < pageSize; // Pull is complete when the number of fetched records is less than page size
+    }
+    
+    // Pull the page as described by the query
+    function pullPage(query, queryId) {
+
+        // Define appropriate parameter to enable fetching of deleted records from the server.
+        // Assumption is that soft delete is enabled on the server table.
+        var params = {};
+        params[tableConstants.includeDeletedFlag] = true;
+        
+        return mobileServiceTable.read(query, params).then(function(pulledRecords) {
+
+            var chain = Platform.async(function(callback) {
+                callback();
+            })();
+            
+            var tableName = query.getComponents().table;
+            
+            // Process all records in the page
+            for (var i in pulledRecords) {
+                chain = processPulledRecord(chain, tableName, pulledRecords[i]); 
+            }
+            
+            // Return the pulled records after we are done processing them
+            return chain.then(function() {
+                return pulledRecords;
+            });
+        });
+    }
+    
+    // Processes the pulled record by taking an appropriate action, which can be one of:
+    // inserting, updating, deleting in the local store or no action at all.
+    function processPulledRecord(chain, tableName, pulledRecord) {
+        return chain.then(function() {
+
+            // Update the store as per the pulled record 
+            return storeTaskRunner.run(function() {
+                if (Validate.isValidId(pulledRecord[idPropertyName])) {
+                    throw new Error('Pulled record does not have a valid ID');
+                }
+                
+                return operationTableManager.readPendingOperations(tableName, pulledRecord[idPropertyName]).then(function(pendingOperations) {
+                    // If there are pending operations for the record we just pulled, we ignore it.
+                    if (pendingOperations.length > 0) {
+                        return;
+                    }
+
+                    if (pulledRecord[sysProps.deletedColumnName] == true) {
+                        return store.del(tableName, pulledRecord.id);
+                    } else if (pulledRecord[sysProps.deletedColumnName] == false) {
+                        return store.upsert(tableName, pulledRecord);
+                    } else {
+                        throw new Error("'" + sysProps.deletedColumnName + "' system property is missing. Pull cannot work without it.'");
+                    }
+                });
+            });
+        });
+    }
+
+    // update the query to pull the next page
+    function updateQueryForNextPage(query, queryId, pulledRecords) {
+        return Platform.async(function(callback) {
+            callback();
+        })().then(function() {
+            if (queryId) { // Incremental pull
+                //TODO: Implement incremental pull
+            } else { // Vanilla pull
+                query.skip(query.getComponents().skip + pulledRecords.length);
+            }
+        });
+    }
+
+    // Not all query operations are allowed while pulling.
+    // This function validates that the query does not perform unsupported operations.
+    function validateQuery(query) {
+        Validate.isObject(query);
+        Validate.notNull(query);
+        
+        var components = query.getComponents();
+        
+        for (var i in components.ordering) {
+            throw new Error('orderBy and orderByDescending clauses are not supported in the pull query');
+        }
+        
+        if (components.skip) {
+            throw new Error('skip is not supported in the pull query');
+        }
+
+        if (components.take) {
+            throw new Error('take is not supported in the pull query');
+        }
+
+        if (components.selections && components.selections.length !== 0) {
+            throw new Error('select is not supported in the pull query');
+        }
+
+        if (components.includeTotalCount) {
+            throw new Error('includeTotalCount is not supported in the pull query');
+        }
+    }
+}
+
+exports.createPullManager = createPullManager;

--- a/sdk/src/sync/push.js
+++ b/sdk/src/sync/push.js
@@ -1,0 +1,177 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * Table push logic implementation
+ */
+
+var Validate = require('../Utilities/Validate'),
+    Query = require('query.js').Query,
+    verror = require('verror'),
+    Platform = require('Platforms/Platform'),
+    taskRunner = require('../Utilities/taskRunner'),
+    MobileServiceTable = require('../MobileServiceTable'),
+    tableConstants = require('../constants').table,
+    sysProps = require('../constants').table.sysProps,
+    createPushError = require('./pushError').createPushError,
+    handlePushError = require('./pushError').handlePushError,
+    _ = require('../Utilities/Extensions');
+
+function createPushManager(client, store, storeTaskRunner, operationTableManager) {
+    // Task runner for running push tasks. We want only one push to run at a time. 
+    var pushTaskRunner = taskRunner(),
+        lastProcessedOperationId,
+        pushConflicts,
+        pushHandler;
+    
+    return {
+        push: push
+    };
+
+    /**
+     * Pushes operations performed on the local store to the server tables.
+     * 
+     * @returns A promise that is fulfilled when all pending operations are pushed. Conflict errors won't fail the push operation.
+     *          All conflicts are collected and returned to the user at the completion of the push operation. 
+     *          The promise is rejected if pushing any record fails for reasons other than conflict or is cancelled.
+     */
+    function push(handler) {
+        return pushTaskRunner.run(function() {
+            reset();
+            pushHandler = handler;
+            return pushAllOperations().then(function() {
+                return pushConflicts;
+            });
+        });
+    }
+    
+    // Resets the state for starting a new push operation
+    function reset() {
+        lastProcessedOperationId = -1; // Initialize to an invalid operation id
+        pushConflicts = [];
+    }
+    
+    // Pushes all pending operations, one at a time.
+    // 1. Read the oldest pending operation
+    // 2. If 1 did not fetch any operation, go to 6.
+    // 3. Lock the operation obtained in step 1 and push it.
+    // 4. If 3 is successful, unlock and remove the locked operation from the operation table and go to 1
+    //    Else if 3 fails, unlock the operation.
+    // 5. If the error is a conflict, handle the conflict and go to 1.
+    // 6. Else, EXIT.
+    function pushAllOperations() {
+        var currentOperation,
+            pushError;
+        return readAndLockFirstPendingOperation().then(function(pendingOperation) {
+            if (!pendingOperation) {
+                return; // No more pending operations. Push is complete
+            }
+            
+            var currentOperation = pendingOperation;
+            
+            return pushOperation(currentOperation).then(function() {
+                return removeLockedOperation();
+            }, function(error) {
+                // failed to push
+                return unlockPendingOperation().then(function() {
+                    pushError = createPushError(store, storeTaskRunner, currentOperation, error);
+                    //TODO: If the conflict isn't resolved but the error is marked as handled by the user,
+                    //we can end up in an infinite loop. Guard against this by capping the max number of 
+                    //times handlePushError can be called for the same record.
+                    return handlePushError(pushError, pushHandler);
+                });
+            }).then(function() {
+                if (!pushError) { // no push error
+                    lastProcessedOperationId = currentOperation.logRecord.id;
+                } else if (pushError && !pushError.isHandled) { // push failed and not handled
+
+                    // For conflict errors, we add the error to the list of errors and continue pushing other records
+                    // For other errors, we abort push.
+                    if (pushError.isConflict()) {
+                        lastProcessedOperationId = currentOperation.logRecord.id;
+                        pushConflicts.push(pushError);
+                    } else { 
+                        throw new verror.VError(pushError.getError(), 'Push failed while pushing operation for tableName : ' + currentOperation.logRecord.tableName +
+                                                                 ', action: ' + currentOperation.logRecord.action +
+                                                                 ', and record ID: ' + currentOperation.logRecord.itemId);
+                    }
+                } else { // push error handled
+                    // No action needed - We want the operation to be re-pushed.
+                    // No special handling is needed even if the operation was cancelled by the user as part of error handling  
+                }
+            }).then(function() {
+                return pushAllOperations(); // push remaining operations
+            });
+        });
+    }
+    
+    function readAndLockFirstPendingOperation() {
+        return storeTaskRunner.run(function() {
+            var pendingOperation;
+            return operationTableManager.readFirstPendingOperationWithData(lastProcessedOperationId).then(function(operation) {
+                pendingOperation = operation;
+                
+                if (!pendingOperation) {
+                    return;
+                }
+                
+                return operationTableManager.lockOperation(pendingOperation.logRecord.id);
+            }).then(function() {
+                return pendingOperation;
+            });
+        });
+    }
+    
+    function unlockPendingOperation() {
+        return storeTaskRunner.run(function() {
+            return operationTableManager.unlockOperation();
+        });
+    }
+    
+    function removeLockedOperation() {
+        return storeTaskRunner.run(function() {
+            return operationTableManager.removeLockedOperation();
+        });
+    }
+    
+    function pushOperation(operation) {
+        
+        return Platform.async(function(callback) {
+            callback();
+        })().then(function() {
+            // TODO: Invoke push request filter to allow user to change how the record is sent to the server
+        }).then(function() {
+            // perform push
+
+            var mobileServiceTable = client.getTable(operation.logRecord.tableName);
+            switch(operation.logRecord.action) {
+                case 'insert':
+                    removeSysProps(operation.data); // We need to remove system properties before we insert in the server table
+                    return mobileServiceTable.insert(operation.data).then(function(result) {
+                        return store.upsert(operation.logRecord.tableName, result); // Upsert the result of insert into the local table
+                    });
+                case 'update':
+                    return mobileServiceTable.update(operation.data).then(function(result) {
+                        return store.upsert(operation.logRecord.tableName, result); // Upsert the result of update into the local table
+                    });
+                case 'delete':
+                    return mobileServiceTable.del({id: operation.logRecord.itemId});
+                default:
+                    throw new Error('Unsupported action ' + operation.logRecord.action);
+            }
+            
+        }).then(function() {
+            // TODO: Invoke hook to notify record push completed successfully
+        });
+        
+    }
+    
+    function removeSysProps(record) {
+        for (var i in sysProps) {
+            delete record[sysProps[i]];
+        }
+    }
+}
+
+exports.createPushManager = createPushManager;

--- a/sdk/src/sync/pushError.js
+++ b/sdk/src/sync/pushError.js
@@ -1,0 +1,311 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * @file Table push error handling implementation. Defines various methods for resolving conflicts
+ */
+
+var Platform = require('Platforms/Platform'),
+    _ = require('../Utilities/Extensions'),
+    tableConstants = require('../constants').table;
+    
+var operationTableName = tableConstants.operationTableName,
+    deletedColumnName = tableConstants.sysProps.deletedColumnName;
+
+/**
+ * Creates a pushError object that wraps the low level error encountered while pushing
+ * and adds other useful methods for error handling.
+ */
+function createPushError(store, storeTaskRunner, pushOperation, operationError) {
+    
+    return {
+        isHandled: false,
+        getError: getError,
+        
+        // Helper methods
+        isConflict: isConflict,
+        
+        // Data query methods
+        getTableName: getTableName,
+        getAction: getAction,
+        getServerRecord: getServerRecord,
+        getClientRecord: getClientRecord,
+        
+        // Error handling methods
+        cancelAndUpdate: cancelAndUpdate,
+        cancelAndDiscard: cancelAndDiscard,
+        cancel: cancel,
+        update: update,
+        changeAction: changeAction
+    };
+    
+    /**
+     * Get the name of the table for which push was performed
+     */
+    function getTableName() {
+        return makeCopy(pushOperation.logRecord.tableName);
+    }
+    
+    /**
+     * Gets the action that was pushed to the server.
+     * Action can be one of 'insert', 'update' or 'delete'.
+     */
+    function getAction() {
+        return makeCopy(pushOperation.logRecord.action);
+    }
+    
+    /**
+     * Gets the value of the server record, if available.
+     * Value of the server record may not be available always.
+     * Example: If the push failed due to a connection error, the value of server
+     * record won't be available.
+     */
+    function getServerRecord() {
+        return makeCopy(operationError.serverInstance);
+    }
+    
+    /**
+     * Gets the value of the client record that was sent to the server.
+     * Note that this may not be the latest value.
+     */
+    function getClientRecord() {
+        return makeCopy(pushOperation.data);
+    }
+    
+    /**
+     * Gets the underlying error.
+     * This contains grannular details about the failure. Egs: server response, etc
+     */
+    function getError() {
+        return makeCopy(operationError);
+    }
+    
+    /**
+     * Checks if the current error is a conflict error.
+     * @returns true - if the current error is a conflict error. false - otherwise.
+     */
+    function isConflict() {
+        return operationError.request.status === 409 || operationError.request.status === 412;
+    }
+    
+    /**
+     * Cancels the push operation for the current record and updates the record in the local store.
+     * 
+     * @param newValue New value of the client record that will be updated in the local store.
+     * 
+     * @returns A promise that is fulfilled when the operation is cancelled and the client record is updated.
+     */
+    function cancelAndUpdate(newValue) {
+        return storeTaskRunner.run(function() {
+
+            if (pushOperation.logRecord.action === 'delete') {
+                throw new Error('Cannot update a deleted record');
+            }
+            
+            if (_.isNull(newValue)) {
+                throw new Error('Need a valid object to update the record');
+            }
+            
+            if (!_.isValidId(newValue.id)) {
+                throw new Error('Invalid ID: ' + newValue.id);
+            }
+            
+            if (newValue.id !== pushOperation.data.id) {
+                throw new Error('Only updating the record being pushed is allowed');
+            }
+            
+            // Operation to update the data record
+            var dataUpdateOperation = {
+                tableName: pushOperation.logRecord.tableName,
+                action: 'upsert',
+                data: newValue
+            };
+            
+            // Operation to delete the log record
+            var logDeleteOperation = {
+                tableName: operationTableName,
+                action: 'delete',
+                id: pushOperation.logRecord.id
+            };
+            
+            // Execute the log and data operations
+            var operations = [dataUpdateOperation, logDeleteOperation];
+            return store.executeBatch(operations);
+        });
+    }
+    
+    /**
+     * Cancels the push operation for the current record and discards the record from the local store.
+     * 
+     * @returns A promise that is fulfilled when the operation is cancelled and the client record is discarded.
+     */
+    function cancelAndDiscard() {
+        return storeTaskRunner.run(function() {
+            
+            // Operation to delete the data record
+            var dataDeleteOperation = {
+                tableName: pushOperation.logRecord.tableName,
+                action: 'delete',
+                id: pushOperation.logRecord.itemId
+            };
+            
+            // Operation to delete the log record
+            var logDeleteOperation = {
+                tableName: operationTableName,
+                action: 'delete',
+                id: pushOperation.logRecord.id
+            };
+            
+            // Execute the log and data operations
+            var operations = [dataDeleteOperation, logDeleteOperation];
+            return store.executeBatch(operations);
+        });
+    }
+    
+    /**
+     * Updates the client data record associated with the current operation.
+     *
+     * @param newValue New value of the data record. 
+     * 
+     * @returns A promise that is fulfilled when the data record is updated in the localstore.
+     */
+    function update(newValue) {
+        return storeTaskRunner.run(function() {
+            if (pushOperation.logRecord.action === 'delete') {
+                throw new Error('Cannot update a deleted record');
+            }
+            
+            if (_.isNull(newValue)) {
+                throw new Error('Need a valid object to update the record');
+            }
+            
+            if (!_.isValidId(newValue.id)) {
+                throw new Error('Invalid ID: ' + newValue.id);
+            }
+            
+            if (newValue.id !== pushOperation.data.id) {
+                throw new Error('Only updating the record being pushed is allowed');
+            }
+
+            //TODO: Do we need to disallow updating record if the record has been deleted after
+            //we attempted push?
+                        
+            return store.upsert(pushOperation.logRecord.tableName, newValue);
+        });
+    }
+    
+    /**
+     * Changes the type of operation that will be pushed to the server.
+     * This is useful for handling conflicts where you might need to change the type of the 
+     * operation to be able to push the changes to the server.
+     *
+     * Example: You might need to change 'insert' to 'update' to be able to push a record that 
+     * was already inserted on the server.
+     * 
+     * Note: Changing the action to delete will automatically remove the associated record from the 
+     * data table in the local store.
+     * 
+     * @param newAction New type of the operation. Valid values are 'insert', 'update' and 'delete'
+     * @param [newClientRecord] New value of the client record. The new record ID should match the original record ID. Also,
+     *                         a new record value cannot be specified if the new action is 'delete'
+     * 
+     * @returns A promise that is fulfilled when the action is changed and, optionally, the data record is updated / deleted.
+     */
+    function changeAction(newAction, newClientRecord) {
+        return storeTaskRunner.run(function() {
+            var dataOperation, // operation to edit the data record
+                logOperation = { // operation to edit the log record 
+                    tableName: operationTableName,
+                    action: 'upsert',
+                    data: makeCopy(pushOperation.logRecord)
+                };
+            
+            if (newAction === 'insert' || newAction === 'update') {
+                
+                // Change the action as specified
+                logOperation.data.action = newAction;
+                
+                // Update the client record, if a new value is specified
+                if (newClientRecord) {
+                    
+                    if (!newClientRecord.id) {
+                        throw new Error('New client record value must specify the record ID');
+                    }
+                    
+                    if (newClientRecord.id !== pushOperation.logRecord.itemId) {
+                        throw new Error('New client record value cannot change the record ID. Original ID: ' + pushOperation.logRecord.id + ' New ID: ' + newClientRecord.id);
+                    }
+                    
+                    dataOperation = {
+                        tableName: pushOperation.logRecord.tableName,
+                        action: 'upsert',
+                        data: newClientRecord
+                    };
+                    
+                }
+                
+            } else if (newAction === 'delete' || newAction === 'del') {
+
+                if (newClientRecord) {
+                    throw new Error('Cannot specify a new value for the client record if the new action is delete');
+                }
+
+                // Change the action to 'delete'
+                logOperation.data.action = 'delete';
+                
+                // Delete the client record as the new action is 'delete'
+                dataOperation = {
+                    tableName: pushOperation.logRecord.tableName,
+                    action: 'delete',
+                    id: pushOperation.logRecord.id
+                };
+
+            } else {
+                throw new Error('Action ' + newAction + ' not supported.');
+            }
+            
+            // Execute the log and data operations
+            var operations = dataOperation ? [logOperation, dataOperation] : [logOperation];
+            return store.executeBatch(operations);
+        });
+    }
+    
+    /**
+     * Cancels pushing the current operation to the server permanently.
+     * 
+     * This method simply removes the pending operation from the operation table, thereby 
+     * permanently skipping the associated change. A future change done to the same record
+     * will not be affected and such changes will continue to be pushed. 
+     */
+    function cancel() {
+        return storeTaskRunner.run(function() {
+            return store.del(operationTableName, pushOperation.logRecord.id);
+        });
+    }
+}
+
+function makeCopy(value) {
+    if (!_.isNull(value)) {
+        value = JSON.parse( JSON.stringify(value) );
+    }
+    return value;
+}
+
+/**
+ * Attempts error handling by delegating it to the user, if a push handler is provided
+ */
+function handlePushError(pushError, pushHandler) {
+    return Platform.async(function(callback) {
+        callback();
+    })().then(function() {
+        
+        // Check if a handler is provided for errors encountered while pushing records
+        if (pushHandler && pushHandler.onRecordPushError) {
+            return pushHandler.onRecordPushError(pushError);
+        }
+    });
+}
+
+exports.createPushError = createPushError;
+exports.handlePushError = handlePushError;

--- a/sdk/test/tests/target/cordova/config.js
+++ b/sdk/test/tests/target/cordova/config.js
@@ -1,0 +1,7 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+module.exports = {
+    server: undefined // backend URL
+};

--- a/sdk/test/tests/target/cordova/offline.functional.tests.js
+++ b/sdk/test/tests/target/cordova/offline.functional.tests.js
@@ -1,0 +1,645 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * Functional tests for offline scenarios
+ */
+
+var Platform = require('Platforms/Platform'),
+    Query = require('query.js').Query,
+    pullManager = require('../../../../src/sync/pull'),
+    _ = require('../../../../src/Utilities/Extensions'),
+    MobileServiceSyncContext = require('../../../../src/sync/MobileServiceSyncContext'),
+    MobileServiceClient = require('../../../../src/MobileServiceClient'),
+    MobileServiceSqliteStore = require('Platforms/MobileServiceSqliteStore'),
+    serverUrl = require('./config').server,
+    uuid = require('node-uuid'),
+    storeTestHelper = require('./storeTestHelper');
+    
+var testTableName = storeTestHelper.testTableName,
+    query = new Query(testTableName),
+    client,
+    table,
+    serverValue,
+    clientValue,
+    currentId,
+    syncContext,
+    filter,
+    id,
+    store;
+
+$testGroup('offline functional tests')
+    .functional()
+    .beforeEachAsync(function() {
+        return storeTestHelper.createEmptyStore().then(function(localStore) {
+            store = localStore;
+            return store.defineTable({
+                name: testTableName,
+                columnDefinitions: {
+                    id: MobileServiceSqliteStore.ColumnType.String,
+                    text: MobileServiceSqliteStore.ColumnType.String,
+                    complete: MobileServiceSqliteStore.ColumnType.Boolean,
+                    version: MobileServiceSqliteStore.ColumnType.String
+                }
+            });
+        }).then(function() {
+            serverValue = clientValue = filter = currentId = undefined;
+            
+            client = new MobileServiceClient(serverUrl);
+            
+            client = client.withFilter(function(req, next, callback) {
+                if (filter) {
+                    filter(req, next, callback);
+                } else {
+                    next(req, callback);
+                }
+            });
+            
+            syncContext = new MobileServiceSyncContext(client);
+            table = client.getTable(testTableName);
+            
+            return syncContext.initialize(store);
+        });
+    }).tests(
+
+    $test('Basic push - insert / update / delete')
+    .description('performs insert, update and delete on the client and pushes each of them individually')
+    .checkAsync(function () {
+        var actions = [
+            'clientinsert', 'push', 'serverlookup',
+            function(result) {
+                $assert.isNotNull(clientValue);
+                $assert.areEqual(result.id, clientValue.id);
+                $assert.areEqual(result.text, clientValue.text);
+            },
+            
+            'clientupdate', 'push', 'serverlookup',
+            function(result) {
+                $assert.isNotNull(clientValue);
+                $assert.areEqual(result.id, clientValue.id);
+                $assert.areEqual(result.text, clientValue.text);
+            },
+            
+            'clientdelete', 'push', 'serverlookup',
+            {
+                success: function(result) {
+                    $assert.fail('should have failed to lookup deleted server record');
+                },
+                fail: function(error) {
+                    // error expected
+                }
+            }
+        ];
+                        
+        return performActions(actions);
+    }),
+    
+    $test('vanilla pull - insert / update / delete')
+    .description('performs insert, update and delete on the server and pulls each of them individually')
+    .checkAsync(function () {
+        var actions = [
+            'serverinsert', 'vanillapull', 'clientlookup',
+            function(result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+            },
+            'serverupdate', 'vanillapull', 'clientlookup',
+            function(result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+            },
+            'serverdelete', 'vanillapull', 'clientlookup',
+            {
+                success: function(result) {
+                    $assert.isNull(result);
+                },
+                fail: function(error) {
+                    $assert.fail(error);
+                }
+            }
+        ];
+        
+        return performActions(actions);
+    }),
+    
+    $test('Push with response 409 - conflict not handled')
+    .description('verifies that push behaves as expected if error is 409 and conflict is not handled')
+    .checkAsync(function () {
+        
+        var actions = [
+            'serverinsert', 'clientinsert', 'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 1);
+                $assert.areEqual(conflicts[0].getError().request.status, 409);
+            }
+        ];
+        
+        return performActions(actions);
+    }),
+    
+    $test('Push with response 409 - conflict handled')
+    .description('verifies that push behaves as expected if error is 409 and conflict is handled')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                var newValue = pushError.getClientRecord();
+
+                $assert.areEqual(pushError.getError().request.status, 409);
+                
+                return table.lookup(newValue.id).then(function(result) {
+                    newValue.version = result.version;
+                    return pushError.changeAction('update');
+                }).then(function() {
+                    pushError.isHandled = true;
+                });
+            }
+        };
+        
+        var actions = [
+            'serverinsert', 'clientinsert', 'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            'serverlookup',
+            function(result) {
+                $assert.areEqual(result.id, clientValue.id);
+                $assert.areEqual(result.text, clientValue.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Push with response 412 - conflict not handled')
+    .description('verifies that push behaves as expected if error is 412 and conflict is not handled')
+    .checkAsync(function () {
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate', 'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 1);
+                $assert.areEqual(conflicts[0].getError().request.status, 412);
+            }
+        ];
+        
+        return performActions(actions);
+    }),
+    
+    $test('Push with response 412 - conflict handled')
+    .description('verifies that push behaves as expected if error is 412 and conflict is handled')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                $assert.areEqual(pushError.getError().request.status, 412);
+                var newValue = pushError.getClientRecord();
+                newValue.version = pushError.getServerRecord().version;
+                pushError.update(newValue);
+                pushError.isHandled = true;
+            }
+        };
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate', 'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            'serverlookup',
+            function(result) {
+                $assert.areEqual(result.id, clientValue.id);
+                $assert.areEqual(result.text, clientValue.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Push - connection error')
+    .checkAsync(function () {
+        
+        filter = function (req, next, callback) {
+            callback(null, { status: 400, responseText: '{"error":"some error"}' });
+        };
+        
+        var actions = [
+            'clientinsert', 'push',
+            {
+                success: function(conflicts) {
+                    $assert.fail('should have failed');
+                },
+                fail: function(error) {
+                    $assert.isNotNull(error);
+                }
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Pull - connection error') 
+    .description('verifies that pull behaves as expected when unable to connect to the server')
+    .checkAsync(function () {
+        
+        filter = function (req, next, callback) {
+            callback(null, { status: 400, responseText: '{"error":"some error"}' });
+        };
+        
+        var actions = [
+            'vanillapull',
+            {
+                success: function(conflicts) {
+                    $assert.fail('should have failed');
+                },
+                fail: function(error) {
+                    $assert.isNotNull(error);
+                }
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Pull - pending changes on client') 
+    .description('Verifies that pull leaves records that are edited on the client untouched')
+    .checkAsync(function () {
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate', 'vanillapull', 'clientlookup',
+            function(result) {
+                $assert.areNotEqual(result.text, serverValue.text);
+            },
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('pushError.update() test')
+    .description('Verifies correctness of error handling function pushError.update()')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                $assert.areEqual(pushError.getError().request.status, 412);
+                var newValue = pushError.getClientRecord();
+                newValue.version = pushError.getServerRecord().version;
+                pushError.update(newValue);
+                pushError.isHandled = true;
+            }
+        };
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate', 'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            'serverlookup',
+            function(result) {
+                $assert.areEqual(result.id, clientValue.id);
+                $assert.areEqual(result.text, clientValue.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('pushError.cancelAndUpdate() test')
+    .description('Verifies correctness of error handling function pushError.cancelAndUpdate()')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                $assert.areEqual(pushError.getError().request.status, 412);
+                var newValue = pushError.getClientRecord();
+                newValue.version = pushError.getServerRecord().version;
+                pushError.cancelAndUpdate(newValue);
+                pushError.isHandled = true;
+                
+                syncContext.pushHandler = undefined;
+            }
+        };
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate',
+            
+            'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            'clientlookup',
+            function(result) {
+                $assert.areNotEqual(result.version, clientValue.version);
+            },
+            'serverlookup',
+            function (result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+                $assert.isNotNull(result.text);
+            },
+            
+            'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            
+            'serverlookup',
+            function (result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+                $assert.isNotNull(result.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('pushError.cancelAndDiscard() test')
+    .description('Verifies correctness of error handling function pushError.cancelAndDiscard()')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                $assert.areEqual(pushError.getError().request.status, 412);
+                var newValue = pushError.getClientRecord();
+                newValue.version = pushError.getServerRecord().version;
+                pushError.cancelAndDiscard(newValue);
+                pushError.isHandled = true;
+                
+                syncContext.pushHandler = undefined;
+            }
+        };
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate',
+            
+            'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            'clientlookup',
+            function(result) {
+                $assert.isNull(result);
+            },
+            'serverlookup',
+            function (result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+                $assert.isNotNull(result.text);
+            },
+            
+            'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 0);
+            },
+            
+            'serverlookup',
+            function (result) {
+                $assert.areEqual(result.id, serverValue.id);
+                $assert.areEqual(result.text, serverValue.text);
+                $assert.isNotNull(result.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Multiple records pushed, one conflict - conflict handled')
+    .description('Verifies that a conflict, if handled, does not prevent other records from being pushed')
+    .checkAsync(function () {
+        
+        syncContext.pushHandler = {};
+        syncContext.pushHandler.onRecordPushError = function (pushError) {
+            if (pushError.isConflict()) {
+                $assert.areEqual(pushError.getError().request.status, 412);
+                var newValue = pushError.getClientRecord();
+                newValue.version = pushError.getServerRecord().version;
+                pushError.update(newValue);
+                pushError.isHandled = true;
+            }
+        };
+        
+        var serverId1, serverId2, serverId3,
+            clientValue1, clientValue2, clientValue3;
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'clientupdate',
+            function() {
+                serverId1 = serverValue.id;
+                clientValue1 = clientValue;
+                currentId = generateId();
+            },
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate',
+            function() {
+                serverId2 = serverValue.id;
+                clientValue2 = clientValue;
+                currentId = generateId();
+            },
+            'serverinsert', 'vanillapull', 'clientupdate',
+            function() {
+                serverId3 = serverValue.id;
+                clientValue3 = clientValue;
+                currentId = generateId();
+            },
+            'push',
+            
+            function() {
+                currentId = serverId1;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areEqual(result.text, clientValue1.text);
+            },
+
+            function() {
+                currentId = serverId2;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areEqual(result.text, clientValue2.text);
+            },
+
+            function() {
+                currentId = serverId3;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areEqual(result.text, clientValue3.text);
+            }
+        ];
+
+        return performActions(actions);
+    }),
+    
+    $test('Multiple records pushed, one conflict - conflict not handled')
+    .description('Verifies that a conflict, if unhandled, does not prevent other records from being pushed')
+    .checkAsync(function () {
+        
+        var serverId1, serverId2, serverId3,
+            clientValue1, clientValue2, clientValue3;
+        
+        var actions = [
+            'serverinsert', 'vanillapull', 'clientupdate',
+            function() {
+                serverId1 = serverValue.id;
+                clientValue1 = clientValue;
+                currentId = generateId();
+            },
+            'serverinsert', 'vanillapull', 'serverupdate', 'clientupdate',
+            function() {
+                serverId2 = serverValue.id;
+                clientValue2 = clientValue;
+                currentId = generateId();
+            },
+            'serverinsert', 'vanillapull', 'clientupdate',
+            function() {
+                serverId3 = serverValue.id;
+                clientValue3 = clientValue;
+                currentId = generateId();
+            },
+            'push',
+            function(conflicts) {
+                $assert.areEqual(conflicts.length, 1);
+            },
+            
+            function() {
+                currentId = serverId1;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areEqual(result.text, clientValue1.text);
+            },
+
+            function() {
+                currentId = serverId2;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areNotEqual(result.text, clientValue2.text);
+            },
+
+            function() {
+                currentId = serverId3;
+            },
+            'serverlookup',
+            function (result) {
+                $assert.isNotNull(result)
+                $assert.isNotNull(result.text)
+                $assert.areEqual(result.text, clientValue3.text);
+            }
+        ];
+
+        return performActions(actions);
+    })   
+);
+
+function performActions (actions) {
+    
+    currentId = generateId(); // generate the ID to use for performing the actions
+    
+    var chain = Platform.async(function(callback) {
+        callback();
+    })();
+    
+    for (var i in actions) {
+        chain = performAction(chain, actions[i]);
+    }
+    
+    return chain;
+}
+
+function performAction (chain, action) {
+    var record;
+    return chain.then(function(result) {
+        if (action && action.success) {
+            return action.success(result);
+        }
+        
+        if (_.isFunction(action)) {
+            return action(result);
+        }
+        
+        switch(action) {
+            case 'clientinsert':
+                record = generateRecord('client-insert');
+                return syncContext.insert(testTableName, record).then(function(result) {
+                    clientValue = result;
+                    return result;
+                });
+            case 'clientupdate':
+                record = generateRecord('client-update')
+                return syncContext.update(testTableName, record).then(function(result) {
+                    clientValue = result;
+                    return result;
+                });
+            case 'clientdelete':
+                record = generateRecord()
+                return syncContext.del(testTableName, record).then(function(result) {
+                    clientValue = undefined;
+                    return result;
+                });
+            case 'clientlookup':
+                return syncContext.lookup(testTableName, currentId);
+            case 'serverinsert':
+                record = generateRecord('server-insert');
+                return table.insert(record).then(function(result) {
+                    serverValue = result;
+                    return result;
+                });
+            case 'serverupdate':
+                record = generateRecord('server-update');
+                return table.update(record).then(function(result) {
+                    serverValue = result;
+                    return result;
+                });
+            case 'serverdelete':
+                record = generateRecord();
+                return table.del(record).then(function(result) {
+                    serverValue = undefined;
+                    return result;
+                });
+            case 'serverlookup':
+                return table.lookup(currentId);
+            case 'push':
+                return syncContext.push();
+            case 'vanillapull':
+                return syncContext.pull(query);
+            default:
+                throw new Error('Unsupported action : ' + action);
+        }
+    }, function(error) {
+        if (action && action.fail) {
+            return action.fail(error);
+        } else {
+            $assert.fail('Unexpected failure while running action : ' + action);
+            $assert.fail(error);
+            throw error;
+        }
+    });
+}
+
+function generateRecord(textPrefix) {
+    return {
+        id: currentId,
+        text: textPrefix + uuid.v4()
+    }
+}
+
+function generateId() {
+    return uuid.v4();
+}


### PR DESCRIPTION
Payload:
- Push implementation with conflict handling support
- Pull implementation

Future work:
- Allowing push / pull to be cancelled
- Pull should trigger a push
- Allow custom page size, etc

Overview:
- SyncContext is the entry point for performing push and pull. It delegates the work to the push / pull modules. An error during is delegated to the pushError module which in turn delegates it to the user for handling (egs: conflict handling).
- User can register for error handling by defining a function MobileServiceSyncContext.onRecordPushError(pushErrors).
- onRecordPushError(pushError) will be called when pushing any record fails. The user can then take appropriate action and mark the error as 'handled'.
- If a non-conflict error is not handled, the push operation is aborted. A conflict that is not handled is noted and a list of all conflicts is returned to the user when push completes.
- pushError contains 4 helper methods for conflict handling: cancel, cancelAndUpdate, cancelAndDiscard and changeActionType (documented in code).


