### PR TITLE
Fix pull implementation to work with .net backends

### DIFF
--- a/sdk/src/sync/pull.js
+++ b/sdk/src/sync/pull.js
@@ -117,14 +117,18 @@ function createPullManager(client, store, storeTaskRunner, operationTableManager
 
         var pulledRecords;
         
-        return mobileServiceTable.read(pagePullQuery, params).then(function(result) {
+        // azure-query-js does not support datatimeoffset
+        // As a temporary workaround, convert the query to an odata string and replace datetime' with datetimeoffset'. 
+        var queryString = pagePullQuery.toOData();
+        var tableName = pagePullQuery.getComponents().table;
+        queryString = queryString.replace(new RegExp('^/' + tableName), '').replace("datetime'", "datetimeoffset'");
+
+        return mobileServiceTable.read(queryString, params).then(function(result) {
             pulledRecords = result;
 
             var chain = Platform.async(function(callback) {
                 callback();
             })();
-            
-            var tableName = pagePullQuery.getComponents().table;
             
             // Process all records in the page
             for (var i in pulledRecords) {

--- a/sdk/test/tests/target/cordova/offline.functional.tests.js
+++ b/sdk/test/tests/target/cordova/offline.functional.tests.js
@@ -781,7 +781,8 @@ function populateServerTable(textPrefix, count) {
     for (var i = 0; i < count; i++) {
         chain = insertRecord(chain, {
             id: generateGuid(),
-            text: generateText(textPrefix) 
+            text: generateText(textPrefix),
+            complete: false 
         });
     }
 
@@ -797,7 +798,8 @@ function insertRecord(chain, record) {
 function generateRecord(textPrefix) {
     return {
         id: currentId,
-        text: generateText(textPrefix)
+        text: generateText(textPrefix),
+        complete: false
     };
 }
 


### PR DESCRIPTION
- datetime queries need to use datetimeoffset to work with .net backends.
- azure-query-js converts Date queries to an odata string that uses "datetime". Ideally azure-query-js should be updated to generate "datetimeoffset" odata queries, but as a quick fix, explicitly changing the query to an odata string and replacing datetime' with datetimeoffset'.
- Changes in the test file are to set a default value for the `complete` property.