### PR TITLE
Pull should stop only when the result size is 0

### DIFF
--- a/sdk/src/sync/MobileServiceSyncTable.js
+++ b/sdk/src/sync/MobileServiceSyncTable.js
@@ -105,7 +105,7 @@ function MobileServiceSyncTable(tableName, client) {
      */
     this.pull = function (query, queryId, settings) {
         return client.getSyncContext().pull(query, queryId, settings);
-    } 
+    }; 
 }
 
 // Define query operators

--- a/sdk/test/tests/target/cordova/offline.functional.tests.js
+++ b/sdk/test/tests/target/cordova/offline.functional.tests.js
@@ -138,6 +138,12 @@ $testGroup('offline functional tests')
         return performPull(60, 'vanillapull');
     }),
 
+    $test('Vanilla pull - tiny page size')
+    .checkAsync(function () {
+        pullPageSize = 1;
+        return performPull(5, 'vanillapull');
+    }),
+
     $test('Vanilla pull - zero records')
     .checkAsync(function () {
         pullPageSize = 4;
@@ -162,15 +168,21 @@ $testGroup('offline functional tests')
         return performPull(4, 'vanillapull');
     }),
 
-    $test('Incremental pull - zero records')
-    .checkAsync(function () {
-        return performPull(0, 'incrementalpull');
-    }),
-
     $test('Incremental pull - default page size')
     .checkAsync(function () {
         // If we are not explicitly defining pullPageSize, the default page size will be used
         return performPull(60, 'incrementalpull');
+    }),
+
+    $test('Incremental pull - tiny page size')
+    .checkAsync(function () {
+        pullPageSize = 1;
+        return performPull(5, 'incrementalpull');
+    }),
+
+    $test('Incremental pull - zero records')
+    .checkAsync(function () {
+        return performPull(0, 'incrementalpull');
     }),
 
     $test('Incremental pull - single page')


### PR DESCRIPTION
- Fixed an incorrect termination condition (`isPullComplete()`).
- Fixed a bug in how date objects were being compared. We need to convert the date objects to seconds since epoch and then compare them.