### PR TITLE
Implement API to close sqlite db connection

### DIFF
--- a/sdk/src/Platforms/cordova/MobileServiceSqliteStore.js
+++ b/sdk/src/Platforms/cordova/MobileServiceSqliteStore.js
@@ -15,26 +15,29 @@ var Platform = require('Platforms/Platform'),
     storeHelper = require('./storeHelper'),
     Query = require('azure-query-js').Query,
     formatSql = require('azure-odata-sql').format,
+    taskRunner = require('../../Utilities/taskRunner'),
     idPropertyName = "id", // TODO: Add support for case insensitive ID and custom ID column
     defaultDbName = 'mobileapps.db';
 
 /**
  * Initializes a new instance of MobileServiceSqliteStore
  */
-var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
+var MobileServiceSqliteStore = function (dbName) {
 
     // Guard against initialization without the new operator
     "use strict";
     if ( !(this instanceof MobileServiceSqliteStore) ) {
         return new MobileServiceSqliteStore(dbName);
     }
-    
+
     if ( _.isNull(dbName) ) {
         dbName = defaultDbName;
     }
 
     this._db = window.sqlitePlugin.openDatabase({ name: dbName, location: 'default' });
-    var tableDefinitions = {};
+
+    var tableDefinitions = {},
+        runner = taskRunner();
 
     /**
      * Defines the schema of the SQLite table
@@ -55,53 +58,52 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      *
      * @returns A promise that is resolved when the operation is completed successfully OR rejected with the error if it fails.
      */
-    this.defineTable = Platform.async(function (tableDefinition) {
+    this.defineTable = function (tableDefinition) {
+        var self = this;
+        return runner.run(function() {
+            storeHelper.validateTableDefinition(tableDefinition);
 
-        // Extract the callback argument added by Platform.async and redefine the function arguments
-        var callback = Array.prototype.pop.apply(arguments);
-        tableDefinition = arguments[0];
+            tableDefinition = JSON.parse(JSON.stringify(tableDefinition)); // clone the table definition as we will need it later
 
-        // Validate the function arguments
-        Validate.isFunction(callback, 'callback');
-        storeHelper.validateTableDefinition(tableDefinition);
 
-        tableDefinition = JSON.parse(JSON.stringify(tableDefinition)); // clone the table definition as we will need it later
+            return Platform.async(function(callback) {
+                self._db.transaction(function(transaction) {
 
-        this._db.transaction(function(transaction) {
+                    // Get the table information
+                    var pragmaStatement = _.format("PRAGMA table_info({0});", tableDefinition.name);
+                    transaction.executeSql(pragmaStatement, [], function (transaction, result) {
 
-            // Get the table information
-            var pragmaStatement = _.format("PRAGMA table_info({0});", tableDefinition.name);
-            transaction.executeSql(pragmaStatement, [], function (transaction, result) {
+                        // Check if a table with the specified name exists 
+                        if (result.rows.length > 0) { // table already exists, add missing columns.
 
-                // Check if a table with the specified name exists 
-                if (result.rows.length > 0) { // table already exists, add missing columns.
+                            // Get a list of columns present in the SQLite table
+                            var existingColumns = {};
+                            for (var i = 0; i < result.rows.length; i++) {
+                                var column = result.rows.item(i);
+                                existingColumns[column.name.toLowerCase()] = true;
+                            }
 
-                    // Get a list of columns present in the SQLite table
-                    var existingColumns = {};
-                    for (var i = 0; i < result.rows.length; i++) {
-                        var column = result.rows.item(i);
-                        existingColumns[column.name.toLowerCase()] = true;
+                            addMissingColumns(transaction, tableDefinition, existingColumns);
+                            
+                        } else { // table does not exist, create it.
+                            createTable(transaction, tableDefinition);
+                        }
+                    });
+
+                }, function (error) {
+                    callback(error);
+                }, function(result) {
+                    // Table definition is successful, update the in-memory list of table definitions. 
+                    try {
+                        storeHelper.addTableDefinition(tableDefinitions, tableDefinition);
+                        callback();
+                    } catch (error) {
+                        callback(error);
                     }
-
-                    addMissingColumns(transaction, tableDefinition, existingColumns);
-                    
-                } else { // table does not exist, create it.
-                    createTable(transaction, tableDefinition);
-                }
-            });
-
-        }, function (error) {
-            callback(error);
-        }, function(result) {
-            // Table definition is successful, update the in-memory list of table definitions. 
-            try {
-                storeHelper.addTableDefinition(tableDefinitions, tableDefinition);
-                callback();
-            } catch (error) {
-                callback(error);
-            }
-        }.bind(this));
-    });
+                });
+            })();
+        });
+    };
 
     /**
      * Updates or inserts one or more objects in the local table
@@ -111,23 +113,20 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      * 
      * @returns A promise that is resolved when the operation is completed successfully OR rejected with the error if it fails.
      */
-    this.upsert = Platform.async(function (tableName, data) {
-        // Extract the callback argument added by Platform.async and redefine the function arguments
-        var callback = Array.prototype.pop.apply(arguments);
-        tableName = arguments[0];
-        data = arguments[1];
-
-        // Validate the arguments
-        Validate.isFunction(callback);
-        
-        this._db.transaction(function(transaction) {
-            this._upsert(transaction, tableName, data);
-        }.bind(this), function (error) {
-            callback(error);
-        }, function () {
-            callback();
+    this.upsert = function (tableName, data) {
+        var self = this;
+        return runner.run(function() {
+            return Platform.async(function(callback) {
+                self._db.transaction(function(transaction) {
+                    self._upsert(transaction, tableName, data);
+                }, function (error) {
+                    callback(error);
+                }, function () {
+                    callback();
+                });
+            })();
         });
-    });
+    };
     
     // Performs the upsert operation.
     // This method validates all arguments, callers can skip validation. 
@@ -248,8 +247,8 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      * rejected with the error if it fials. 
      */
     this.lookup = function (tableName, id, suppressRecordNotFoundError) {
-
-        return Platform.async(function(callback) {
+        var self = this;
+        return runner.run(function() {
             // Validate the arguments
             Validate.isString(tableName, 'tableName');
             Validate.notNullOrEmpty(tableName, 'tableName');
@@ -262,30 +261,31 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
 
             var lookupStatement = _.format("SELECT * FROM [{0}] WHERE {1} = ? COLLATE NOCASE", tableName, idPropertyName);
 
-            this._db.executeSql(lookupStatement, [id], function (result) {
+            return Platform.async(function(callback) {
+                self._db.executeSql(lookupStatement, [id], function (result) {
+                    try {
+                        var record;
+                        if (result.rows.length !== 0) {
+                            record = result.rows.item(0);
+                        }
 
-                try {
-                    var record;
-                    if (result.rows.length !== 0) {
-                        record = result.rows.item(0);
+                        if (record) {
+                            // Deserialize the record read from the SQLite store into its original form.
+                            record = sqliteSerializer.deserialize(record, tableDefinition.columnDefinitions);
+                            callback(null, record);
+                        } else if (suppressRecordNotFoundError) {
+                            callback();
+                        } else {
+                            callback(new Error('Item with id "' + id + '" does not exist.'));
+                        }
+                    } catch (err) {
+                        callback(err);
                     }
-
-                    if (record) {
-                        // Deserialize the record read from the SQLite store into its original form.
-                        record = sqliteSerializer.deserialize(record, tableDefinition.columnDefinitions);
-                        callback(null, record);
-                    } else if (suppressRecordNotFoundError) {
-                        callback();
-                    } else {
-                        callback(new Error('Item with id "' + id + '" does not exist.'));
-                    }
-                } catch (err) {
+                }, function (err) {
                     callback(err);
-                }
-            }, function (err) {
-                callback(err);
-            });
-        }.bind(this))();
+                });
+            })();
+        });
     };
 
     /**
@@ -298,45 +298,43 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      * 
      * @returns Promise that is resolved when the operation completes successfully or rejected with the error if it fails.
      */
-    this.del = Platform.async(function (tableNameOrQuery, ids) {
+    this.del = function (tableNameOrQuery, ids) {
+        var self = this;
+        return runner.run(function() {
+            return Platform.async(function(callback) {
+                // Validate parameters
+                Validate.notNull(tableNameOrQuery);
 
-        // Extract the callback argument added by Platform.async and redefine the function arguments
-        var callback = Array.prototype.pop.apply(arguments);
-        tableNameOrQuery = arguments[0];
-        ids = arguments[1];
+                if (_.isString(tableNameOrQuery)) { // tableNameOrQuery is table name, delete records with specified IDs.
+                    Validate.notNullOrEmpty(tableNameOrQuery, 'tableNameOrQuery');
 
-        // Validate parameters
-        Validate.isFunction(callback);
-        Validate.notNull(tableNameOrQuery);
-
-        if (_.isString(tableNameOrQuery)) { // tableNameOrQuery is table name, delete records with specified IDs.
-            Validate.notNullOrEmpty(tableNameOrQuery, 'tableNameOrQuery');
-
-            // If a single id is specified, convert it to an array and proceed.
-            // Detailed validation of individual IDs in the array will be taken care of later.
-            if (!_.isArray(ids)) {
-                ids = [ids];
-            }
-            
-            this._db.transaction(function(transaction) {
-                for (var i in ids) {
-                    if (! _.isNull(ids[i])) {
-                        Validate.isValidId(ids[i]);
+                    // If a single id is specified, convert it to an array and proceed.
+                    // Detailed validation of individual IDs in the array will be taken care of later.
+                    if (!_.isArray(ids)) {
+                        ids = [ids];
                     }
-                }
-                this._deleteIds(transaction, tableNameOrQuery /* table name */, ids);
-            }.bind(this), function (error) {
-                callback(error);
-            }, function () {
-                callback();
-            });
+                    
+                    self._db.transaction(function(transaction) {
+                        for (var i in ids) {
+                            if (! _.isNull(ids[i])) {
+                                Validate.isValidId(ids[i]);
+                            }
+                        }
+                        self._deleteIds(transaction, tableNameOrQuery /* table name */, ids);
+                    }, function (error) {
+                        callback(error);
+                    }, function () {
+                        callback();
+                    });
 
-        } else if (_.isObject(tableNameOrQuery)) { // tableNameOrQuery is a query, delete all records specified by the query.
-            this._deleteUsingQuery(tableNameOrQuery /* query */, callback);
-        } else { // error
-            throw _.format(Platform.getResourceString("TypeCheckError"), 'tableNameOrQuery', 'Object or String', typeof tableNameOrQuery);
-        }
-    });
+                } else if (_.isObject(tableNameOrQuery)) { // tableNameOrQuery is a query, delete all records specified by the query.
+                    self._deleteUsingQuery(tableNameOrQuery /* query */, callback);
+                } else { // error
+                    throw _.format(Platform.getResourceString("TypeCheckError"), 'tableNameOrQuery', 'Object or String', typeof tableNameOrQuery);
+                }
+            })();
+        });
+    };
     
     // Deletes the records selected by the specified query and notifies the callback.
     this._deleteUsingQuery = function (query, callback) {
@@ -411,62 +409,65 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      * @returns A promise that is resolved with the read results when the operation is completed successfully or rejected with
      *          the error if it fails.
      */
-    this.read = Platform.async(function (query) {
+    this.read = function (query) {
+        return runner.run(function() {
+            Validate.notNull(query, 'query');
+            Validate.isObject(query, 'query');
 
-        // Extract the callback argument added by Platform.async and redefine the function arguments
-        var callback = Array.prototype.pop.apply(arguments);
-        query = arguments[0];
+            return this._read(query);
+        }.bind(this));
+    };
 
-        Validate.isFunction(callback, 'callback');
-        Validate.notNull(query, 'query');
-        Validate.isObject(query, 'query');
+    this._read = function (query) {
+        return Platform.async(function(callback) {
 
-        var tableDefinition = storeHelper.getTableDefinition(tableDefinitions, query.getComponents().table);
-        if (_.isNull(tableDefinition)) {
-            throw new Error('Definition not found for table "' + query.getComponents().table + '"');
-        }
-
-        var count,
-            result = [],
-            statements = getSqlStatementsFromQuery(query);
-
-        this._db.transaction(function (transaction) {
-
-            // If the query requests the result count we expect 2 SQLite statements. Else, we expect a single statement.
-            if (statements.length < 1 || statements.length > 2) {
-                throw Platform.getResourceString("MobileServiceSqliteStore_UnexptedNumberOfStatements");
+            var tableDefinition = storeHelper.getTableDefinition(tableDefinitions, query.getComponents().table);
+            if (_.isNull(tableDefinition)) {
+                throw new Error('Definition not found for table "' + query.getComponents().table + '"');
             }
 
-            // The first statement gets the query results. Execute it.
-            // TODO: Figure out a better way to determine what the statements in the array correspond to.    
-            transaction.executeSql(statements[0].sql, getStatementParameters(statements[0]), function (transaction, res) {
-                var record;
-                for (var j = 0; j < res.rows.length; j++) {
-                    // Deserialize the record read from the SQLite store into its original form.
-                    record = sqliteSerializer.deserialize(res.rows.item(j), tableDefinition.columnDefinitions);
-                    result.push(record);
+            var count,
+                result = [],
+                statements = getSqlStatementsFromQuery(query);
+
+            this._db.transaction(function (transaction) {
+
+                // If the query requests the result count we expect 2 SQLite statements. Else, we expect a single statement.
+                if (statements.length < 1 || statements.length > 2) {
+                    throw Platform.getResourceString("MobileServiceSqliteStore_UnexptedNumberOfStatements");
                 }
-            });
 
-            // Check if there are multiple statements. If yes, the second is for the result count.
-            if (statements.length === 2) {
-                transaction.executeSql(statements[1].sql, getStatementParameters(statements[1]), function (transaction, res) {
-                    count = res.rows.item(0).count;
+                // The first statement gets the query results. Execute it.
+                // TODO: Figure out a better way to determine what the statements in the array correspond to.    
+                transaction.executeSql(statements[0].sql, getStatementParameters(statements[0]), function (transaction, res) {
+                    var record;
+                    for (var j = 0; j < res.rows.length; j++) {
+                        // Deserialize the record read from the SQLite store into its original form.
+                        record = sqliteSerializer.deserialize(res.rows.item(j), tableDefinition.columnDefinitions);
+                        result.push(record);
+                    }
                 });
-            }
-        }, function (error) {
-            callback(error);
-        }, function () {
-            // If we fetched the record count, combine the records and the count into an object.
-            if (count !== undefined) {
-                result = {
-                    result: result,
-                    count: count
-                };
-            }
-            callback(null, result);
-        });
-    });
+
+                // Check if there are multiple statements. If yes, the second is for the result count.
+                if (statements.length === 2) {
+                    transaction.executeSql(statements[1].sql, getStatementParameters(statements[1]), function (transaction, res) {
+                        count = res.rows.item(0).count;
+                    });
+                }
+            }, function (error) {
+                callback(error);
+            }, function () {
+                // If we fetched the record count, combine the records and the count into an object.
+                if (count !== undefined) {
+                    result = {
+                        result: result,
+                        count: count
+                    };
+                }
+                callback(null, result);
+            });
+        }.bind(this))();
+    };
     
     /**
      * Executes the specified operations as part of a single SQL transaction.
@@ -488,49 +489,45 @@ var MobileServiceSqliteStore = function (dbName) { //TODO: allow null dbName
      * 
      * @returns A promise that is resolved when the operations are completed successfully OR rejected with the error if they fail.
      */
-    this.executeBatch = Platform.async(function (operations) {
+    this.executeBatch = function (operations) {
+        var self = this;
+        return runner.run(function() {
+            Validate.isArray(operations);
 
-        // Extract the callback argument added by Platform.async and redefine the function arguments
-        var callback = Array.prototype.pop.apply(arguments);
-        operations = arguments[0];
+            return Platform.async(function(callback) {
+                self._db.transaction(function(transaction) {
+                    for (var i in operations) {
+                        var operation = operations[i];
+                        
+                        if (_.isNull(operation)) {
+                            continue;
+                        }
+                        
+                        Validate.isString(operation.action);
+                        Validate.notNullOrEmpty(operation.action);
 
-        // Validate the function arguments
-        Validate.isFunction(callback, 'callback');
-        Validate.isArray(operations);
-        
-        this._db.transaction(function(transaction) {
-            for (var i in operations) {
-                var operation = operations[i];
-                
-                if (_.isNull(operation)) {
-                    continue;
-                }
-                
-                Validate.isString(operation.action);
-                Validate.notNullOrEmpty(operation.action);
-
-                Validate.isString(operation.tableName);
-                Validate.notNullOrEmpty(operation.tableName);
-                
-                if (operation.action.toLowerCase() === 'upsert') {
-                    this._upsert(transaction, operation.tableName, operation.data);
-                } else if (operation.action.toLowerCase() === 'delete') {
-                    if ( ! _.isNull(operation.id) ) {
-                        Validate.isValidId(operation.id);
-                        this._deleteIds(transaction, operation.tableName, [operation.id]);
+                        Validate.isString(operation.tableName);
+                        Validate.notNullOrEmpty(operation.tableName);
+                        
+                        if (operation.action.toLowerCase() === 'upsert') {
+                            self._upsert(transaction, operation.tableName, operation.data);
+                        } else if (operation.action.toLowerCase() === 'delete') {
+                            if ( ! _.isNull(operation.id) ) {
+                                Validate.isValidId(operation.id);
+                                self._deleteIds(transaction, operation.tableName, [operation.id]);
+                            }
+                        } else {
+                            throw new Error(_.format("Operation '{0}' is not supported", operation.action));
+                        }
                     }
-                } else {
-                    throw new Error(_.format("Operation '{0}' is not supported", operation.action));
-                }
-            }
-        }.bind(this), function (error) {
-            callback(error);
-        }, function () {
-            callback();
+                }, function (error) {
+                    callback(error);
+                }, function () {
+                    callback();
+                });
+            })();
         });
-    });
-
-    
+    };
 };
 
 // Converts the QueryJS object into equivalent SQLite statements

--- a/sdk/test/tests/target/cordova/mobileServiceSqliteStore.initClose.js
+++ b/sdk/test/tests/target/cordova/mobileServiceSqliteStore.initClose.js
@@ -1,0 +1,138 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * @file MobileServiceSqliteStore.defineTable(..) unit tests
+ */
+
+var Platform = require('Platforms/Platform'),
+    Query = require('query.js').Query,
+    MobileServiceSqliteStore = require('Platforms/MobileServiceSqliteStore'),
+    storeTestHelper = require('./storeTestHelper'),
+    runActions = require('../../shared/testHelper').runActions;
+    
+var store;
+
+$testGroup('SQLiteStore - init / close tests').tests(
+
+    $test('basic init')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore();
+
+        $assert.isNull(store._db);
+        return runActions([
+            [store, store.init],
+            function() {
+                $assert.isNotNull(store._db);
+            }
+        ]);
+    }),
+
+    $test('double init')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore(),
+            db;
+
+        $assert.isNull(store._db);
+
+        return runActions([
+            [store, store.init],
+            function() {
+                db = store._db;
+                $assert.isNotNull(store._db);
+            },
+            [store, store.init],
+            function() {
+                $assert.areEqual(store._db, db);
+            }
+        ]);
+    }),
+
+    $test('init error - invalid db name')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore('.'), // invalid db name to force an error
+            db;
+
+        $assert.isNull(store._db);
+
+        return runActions([
+            [store, store.init],
+            {
+                fail: function(error) {
+                    // no action needed - error expected
+                }
+            }
+        ]);
+    }),
+
+    $test('init error - invalid `this` value')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore(),
+            db;
+
+        $assert.isNull(store._db);
+
+        return runActions([
+            [undefined /* undefined this value */, store.init],
+            {
+                fail: function(error) {
+                    // no action needed - error expected
+                }
+            }
+        ]);
+    }),
+
+    $test('basic close')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore();
+
+        $assert.isNull(store._db);
+        return runActions([
+            [store, store.init],
+            function() {
+                $assert.isNotNull(store._db);
+            },
+            [store, store.close],
+            function() {
+                $assert.isNull(store._db);
+            }
+        ]);
+    }),
+
+    $test('double close')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore();
+
+        $assert.isNull(store._db);
+        return runActions([
+            [store, store.init],
+            function() {
+                $assert.isNotNull(store._db);
+            },
+            [store, store.close],
+            function() {
+                $assert.isNull(store._db);
+            },
+            [store, store.close],
+            function() {
+                $assert.isNull(store._db);
+            }
+        ]);
+    }),
+
+    $test('close error - invalid `this` value')
+    .checkAsync(function () {
+        var store = MobileServiceSqliteStore();
+
+        $assert.isNull(store._db);
+        return runActions([
+            [undefined /* undefined this value */, store.close],
+            {
+                fail: function(error) {
+                    // no action needed - failure expected
+                }
+            }
+        ]);
+    })
+);

--- a/sdk/test/tests/target/cordova/mobileServiceSqliteStore.lookup.tests.js
+++ b/sdk/test/tests/target/cordova/mobileServiceSqliteStore.lookup.tests.js
@@ -140,7 +140,7 @@ $testGroup('SQLiteStore - lookup tests')
         });
     }),
 
-    $test('record not found')
+    $test('record not found - suppressRecordNotFoundError === false')
     .checkAsync(function () {
         return store.defineTable({
             name: storeTestHelper.testTableName,
@@ -157,7 +157,7 @@ $testGroup('SQLiteStore - lookup tests')
         });
     }),
 
-    $test('Suppress lookup failure')
+    $test('record not found - suppressRecordNotFoundError === true')
     .description('Check that promise returned by lookup is either resolved or rejected even when invoked with extra parameters')
     .checkAsync(function () {
         return store.defineTable({

--- a/sdk/test/tests/target/cordova/mobileServiceSqliteStore.misc.tests.js
+++ b/sdk/test/tests/target/cordova/mobileServiceSqliteStore.misc.tests.js
@@ -207,25 +207,25 @@ $testGroup('SQLiteStore - miscellaneous tests')
     $test('Verify MobileServiceSqliteStore initialization works as expected with the new operator')
     .check(function () {
         var store = new MobileServiceSqliteStore('somedbname');
-        $assert.isNotNull(store._db);
+        $assert.isNotNull(store.upsert);
     }),
     
     $test('Verify MobileServiceSqliteStore initialization works as expected without the new operator')
     .check(function () {
         var store = MobileServiceSqliteStore('somedbname');
         $assert.isNotNull(store, 'somedbname');
-        $assert.isNotNull(store._db);
+        $assert.isNotNull(store.upsert);
     }),
     
     $test('MobileServiceSqliteStore constructor without db name')
     .check(function () {
         var localStore = MobileServiceSqliteStore('somedbname');
-        $assert.isNotNull(localStore._db);
+        $assert.isNotNull(store.upsert);
     }),
     
     $test('MobileServiceSqliteStore constructor with a null db name')
     .check(function () {
         var localStore = MobileServiceSqliteStore('somedbname');
-        $assert.isNotNull(localStore._db);
+        $assert.isNotNull(store.upsert);
     })
 );

--- a/sdk/test/tests/target/cordova/storeTestHelper.js
+++ b/sdk/test/tests/target/cordova/storeTestHelper.js
@@ -19,12 +19,16 @@ var Platform = require('Platforms/Platform'),
 // Method need not be async, but defining it async to be consistent with createEmptyStore    
 function createStore() {
     return Platform.async(function(callback) {
+        callback();
+    })().then(function() {
         if (!store) {
             store = new MobileServiceSqliteStore(testDbFile);
         }
 
-        callback(null, Object.create(store));
-    })();
+        return store.init(); 
+    }).then(function() {
+        return Object.create(store);
+    });
 }
 
 function resetStore(store) {


### PR DESCRIPTION
- This PR closes https://github.com/Azure/azure-mobile-apps-js-client/issues/128 
- `init` opens a connection to the sqlite db and `close` closes the connection. `defineTable` implicitly calls `init()`.
- Also, execution of all store operations is now serialized
- More details in description of individual commits