### PR TITLE
Fix conflict detection failure while pushing local delete operations

### DIFF
--- a/sdk/src/sync/MobileServiceSyncContext.js
+++ b/sdk/src/sync/MobileServiceSyncContext.js
@@ -28,6 +28,7 @@ function MobileServiceSyncContext(client) {
         operationTableManager,
         pullManager,
         pushManager,
+        purgeManager,
         isInitialized = false,
         syncTaskRunner = taskRunner(), // Used to run push / pull tasks
         storeTaskRunner = taskRunner(); // Used to run insert / update / delete tasks on the store
@@ -177,7 +178,7 @@ function MobileServiceSyncContext(client) {
                 throw new Error('MobileServiceSyncContext not initialized');
             }
 
-            return operationTableManager.getLoggingOperation(tableName, 'delete', instance.id).then(function(loggingOperation) {
+            return operationTableManager.getLoggingOperation(tableName, 'delete', instance).then(function(loggingOperation) {
                 return store.executeBatch([
                     {
                         action: 'delete',
@@ -278,7 +279,7 @@ function MobileServiceSyncContext(client) {
                 throw new Error('Record with ID ' + existingRecord.id + ' already exists in the table ' + tableName);
             }
         }).then(function() {
-            return operationTableManager.getLoggingOperation(tableName, action, instance.id);
+            return operationTableManager.getLoggingOperation(tableName, action, instance);
         }).then(function(loggingOperation) {
             return store.executeBatch([
                 {

--- a/sdk/src/sync/push.js
+++ b/sdk/src/sync/push.js
@@ -76,7 +76,7 @@ function createPushManager(client, store, storeTaskRunner, operationTableManager
             }, function(error) {
                 // failed to push
                 return unlockPendingOperation().then(function() {
-                    pushError = createPushError(store, storeTaskRunner, currentOperation, error);
+                    pushError = createPushError(store, operationTableManager, storeTaskRunner, currentOperation, error);
                     //TODO: If the conflict isn't resolved but the error is marked as handled by the user,
                     //we can end up in an infinite loop. Guard against this by capping the max number of 
                     //times handlePushError can be called for the same record.
@@ -158,7 +158,9 @@ function createPushManager(client, store, storeTaskRunner, operationTableManager
                         return store.upsert(operation.logRecord.tableName, result); // Upsert the result of update into the local table
                     });
                 case 'delete':
-                    return mobileServiceTable.del({id: operation.logRecord.itemId});
+                    // Use the version info form the log record.
+                    operation.logRecord.metadata = operation.logRecord.metadata || {};
+                    return mobileServiceTable.del({id: operation.logRecord.itemId, version: operation.logRecord.metadata.version});
                 default:
                     throw new Error('Unsupported action ' + operation.logRecord.action);
             }

--- a/sdk/test/tests/target/cordova/mobileServiceSyncContext.tests.js
+++ b/sdk/test/tests/target/cordova/mobileServiceSyncContext.tests.js
@@ -360,7 +360,7 @@ function performActionWithCustomLogging(id, action) {
     var syncContext;
     return getSyncContext().then(function(context) {
         syncContext = context;
-        syncContext._getOperationTableManager().getLoggingOperation = function(tableName, action, itemId) {
+        syncContext._getOperationTableManager().getLoggingOperation = function(tableName, action, item) {
             return Platform.async(function(callback) {
                 callback();
             })().then(function() {
@@ -371,7 +371,7 @@ function performActionWithCustomLogging(id, action) {
                         id: testOperationId,
                         tableName: tableName,
                         action: action + '_override',
-                        itemId: itemId
+                        itemId: item.id
                     }
                 };
             });
@@ -405,7 +405,7 @@ function createSyncContextWithLongExecutionTime(callback1, callback2) {
         // Override getLoggingOperation() and simulate long execution time
         
         var getLoggingOperation = syncContext._getOperationTableManager().getLoggingOperation;
-        syncContext._getOperationTableManager().getLoggingOperation = function(tableName, action, itemId) {
+        syncContext._getOperationTableManager().getLoggingOperation = function(tableName, action, item) {
             var args = arguments;
             callback1();
             return Platform.async(function(callback) {

--- a/sdk/test/tests/target/cordova/operations.tests.js
+++ b/sdk/test/tests/target/cordova/operations.tests.js
@@ -17,7 +17,9 @@ var createOperationTableManager = operations.createOperationTableManager,
     operationTableName = tableConstants.operationTableName,
     store,
     testId = 'abc',
-    testItem = {id: testId};
+    testVersion = 'testversion',
+    testItem = {id: testId},
+    testMetadata = {version: 'someversion'};
 
 $testGroup('operations tests')
 
@@ -29,7 +31,8 @@ $testGroup('operations tests')
             return store.defineTable({
                 name: storeTestHelper.testTableName,
                 columnDefinitions: {
-                    id: MobileServiceSqliteStore.ColumnType.String
+                    id: MobileServiceSqliteStore.ColumnType.String,
+                    version: MobileServiceSqliteStore.ColumnType.String
                 }
             });
         });
@@ -64,7 +67,8 @@ $testGroup('operations tests')
                     action: 'insert',
                     id: 1,
                     itemId: testId,
-                    tableName: storeTestHelper.testTableName
+                    tableName: storeTestHelper.testTableName,
+                    metadata: {}
                 }
             ]);
         }, function(error) {
@@ -83,14 +87,15 @@ $testGroup('operations tests')
         }).then(function(op) {
             return store.executeBatch([op]);
         }).then(function() {
-            return operationTableManager.readPendingOperations(storeTestHelper.testTableName, item1);
+            return operationTableManager.readPendingOperations(storeTestHelper.testTableName, item1.id);
         }).then(function(result) {
             $assert.areEqual(result, [
                 {
                     action: 'insert',
                     id: 1,
                     itemId: item1.id,
-                    tableName: storeTestHelper.testTableName
+                    tableName: storeTestHelper.testTableName,
+                    metadata: {}
                 }
             ]);
         }).then(function() {
@@ -98,7 +103,7 @@ $testGroup('operations tests')
         }).then(function(op) {
             return store.executeBatch([op]);
         }).then(function() {
-            return operationTableManager.getLoggingOperation(storeTestHelper.testTableName, 'insert', item1); // insert item1
+            return operationTableManager.getLoggingOperation(storeTestHelper.testTableName, 'insert', item1); // insert item1 again
         }).then(function(op) {
             return store.executeBatch([op]);
         }).then(function() {
@@ -109,7 +114,8 @@ $testGroup('operations tests')
                     action: 'insert',
                     id: 2,
                     itemId: item1.id,
-                    tableName: storeTestHelper.testTableName
+                    tableName: storeTestHelper.testTableName,
+                    metadata: {}
                 }
             ]);
         }).then(function() {
@@ -120,14 +126,15 @@ $testGroup('operations tests')
         }).then(function(op) {
             return store.executeBatch([op]);
         }).then(function() {
-            return operationTableManager.readPendingOperations(storeTestHelper.testTableName, item2);
+            return operationTableManager.readPendingOperations(storeTestHelper.testTableName, item2.id);
         }).then(function(result) {
             $assert.areEqual(result, [
                 {
                     action: 'insert',
                     id: 3,
                     itemId: item2.id,
-                    tableName: storeTestHelper.testTableName
+                    tableName: storeTestHelper.testTableName,
+                    metadata: {}
                 }
             ]);
         }, function(error) {
@@ -284,13 +291,13 @@ $testGroup('operations tests')
     $test('readFirstPendingOperationWithData reads - insert log operation')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1001, action: 'update', tableName: storeTestHelper.testTableName, itemId: 'a' },
-            logRecord2 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b' },
-            logRecord3 = { id: 1002,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'c' },
-            logRecord4 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd' },
-            data1 = { id: 'a' },
-            data2 = { id: 'b' },
-            data3 = { id: 'c' };            
+        var logRecord1 = { id: 1001, action: 'update', tableName: storeTestHelper.testTableName, itemId: 'a', metadata: testMetadata },
+            logRecord2 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata },
+            logRecord3 = { id: 1002,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'c', metadata: testMetadata },
+            logRecord4 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd', metadata: testMetadata },
+            data1 = { id: 'a', version: testVersion },
+            data2 = { id: 'b', version: testVersion },
+            data3 = { id: 'c', version: testVersion };            
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -326,13 +333,13 @@ $testGroup('operations tests')
     $test('readFirstPendingOperationWithData - update log operation')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1001, action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'a' },
-            logRecord2 = { id: 1,    action: 'update', tableName: storeTestHelper.testTableName, itemId: 'b' },
-            logRecord3 = { id: 500,    action: 'update', tableName: storeTestHelper.testTableName, itemId: 'c' },
-            logRecord4 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd' },
-            data1 = { id: 'a' },
-            data2 = { id: 'b' },
-            data3 = { id: 'c' };
+        var logRecord1 = { id: 1001, action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'a', metadata: testMetadata },
+            logRecord2 = { id: 1,    action: 'update', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata },
+            logRecord3 = { id: 500,    action: 'update', tableName: storeTestHelper.testTableName, itemId: 'c', metadata: testMetadata },
+            logRecord4 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd', metadata: testMetadata },
+            data1 = { id: 'a', version: testVersion },
+            data2 = { id: 'b', version: testVersion },
+            data3 = { id: 'c', version: testVersion };
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -368,12 +375,12 @@ $testGroup('operations tests')
     $test('readFirstPendingOperationWithData - delete log operation')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1001, action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'a' },
-            logRecord2 = { id: 1,    action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd1' },
-            logRecord3 = { id: 5000,    action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd2' },
-            logRecord4 = { id: 2001, action: 'update', tableName: storeTestHelper.testTableName, itemId: 'b' },
-            data1 = { id: 'a' },
-            data2 = { id: 'b' };            
+        var logRecord1 = { id: 1001, action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'a', metadata: testMetadata },
+            logRecord2 = { id: 1,    action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd1', metadata: testMetadata },
+            logRecord3 = { id: 5000,    action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd2', metadata: testMetadata },
+            logRecord4 = { id: 2001, action: 'update', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata },
+            data1 = { id: 'a', version: testVersion },
+            data2 = { id: 'b', version: testVersion };            
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -406,11 +413,11 @@ $testGroup('operations tests')
     $test('readFirstPendingOperationWithData - first log record without data record, next log record has data record')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1001, action: 'udpate', tableName: storeTestHelper.testTableName, itemId: 'a' },
-            logRecord2 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b' },
-            logRecord3 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd' },
-            data1 = { id: 'a' },
-            data2 = { id: 'c' };            
+        var logRecord1 = { id: 1001, action: 'udpate', tableName: storeTestHelper.testTableName, itemId: 'a', metadata: testMetadata },
+            logRecord2 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata },
+            logRecord3 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd', metadata: testMetadata },
+            data1 = { id: 'a', version: testVersion },
+            data2 = { id: 'c', version: testVersion };            
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -438,7 +445,7 @@ $testGroup('operations tests')
     $test('readFirstPendingOperationWithData - first log record without data record, next log record does not exist')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b' };            
+        var logRecord1 = { id: 1,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata };            
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -472,9 +479,9 @@ $testGroup('operations tests')
     $test('removeLockedOperation')
     .checkAsync(function () {
         var operationTableManager = createOperationTableManager(store);
-        var logRecord1 = { id: 1, action: 'udpate', tableName: storeTestHelper.testTableName, itemId: 'a' },
-            logRecord2 = { id: 101,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b' },
-            logRecord3 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd' };            
+        var logRecord1 = { id: 1, action: 'udpate', tableName: storeTestHelper.testTableName, itemId: 'a', metadata: testMetadata },
+            logRecord2 = { id: 101,    action: 'insert', tableName: storeTestHelper.testTableName, itemId: 'b', metadata: testMetadata },
+            logRecord3 = { id: 2001, action: 'delete', tableName: storeTestHelper.testTableName, itemId: 'dd', metadata: testMetadata };
             
         return operationTableManager.initialize().then(function() {
             return store.executeBatch([
@@ -493,8 +500,201 @@ $testGroup('operations tests')
         }, function(error) {
             $assert.fail(error);
         });
+    }),
+
+    // getMetadata tests - action: insert
+
+    $test('getMetadata - action is insert, new record has version')
+    .checkAsync(function () {
+        return verify_getMetadata('insert', undefined, {version: testVersion}, {version: testVersion});
+    }),
+    
+    $test('getMetadata - action is insert, new record has null version')
+    .checkAsync(function () {
+        return verify_getMetadata('insert', undefined, {version: null}, {version: null});
+    }),
+    
+    $test('getMetadata - action is insert, new record has no version')
+    .checkAsync(function () {
+        return verify_getMetadata('insert', undefined, {}, {version: undefined});
+    }),
+    
+    // getMetadata tests - action: upsert
+
+    $test('getMetadata - action is upsert, new record has version')
+    .checkAsync(function () {
+        return verify_getMetadata('upsert', undefined, {version: testVersion}, {version: testVersion});
+    }),
+    
+    $test('getMetadata - action is upsert, new record has null version')
+    .checkAsync(function () {
+        return verify_getMetadata('upsert', undefined, {version: null}, {version: null});
+    }),
+    
+    $test('getMetadata - action is upsert, new record has no version')
+    .checkAsync(function () {
+        return verify_getMetadata('upsert', undefined, {}, {version: undefined});
+    }),
+    
+    // getMetadata tests - action: update
+
+    $test('getMetadata - action is update, store has no such record, new record has version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', undefined, {version: testVersion}, {version: testVersion});
+    }),
+    
+    $test('getMetadata - action is update, store has no such record, new record has null version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', undefined, {version: null}, {version: null});
+    }),
+    
+    $test('getMetadata - action is update, store has no such record, new record has no version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', undefined, {}, {});
+    }),
+    
+    $test('getMetadata - action is update, store has record without version, new record has version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: undefined}, {version: testVersion}, {version: testVersion});
+    }),
+    
+    $test('getMetadata - action is update, store has record without version, new record has null version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: undefined}, {version: null}, {version: null});
+    }),
+    
+    $test('getMetadata - action is update, store has record without version, new record has no version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: undefined}, {}, {version: null});
+    }),
+    
+    $test('getMetadata - action is update, store has record with version, new record has new version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: 'oldversion'}, {version: testVersion}, {version: testVersion});
+    }),
+
+    $test('getMetadata - action is update, store has record with version, new record has same version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: testVersion}, {version: testVersion}, {version: testVersion});
+    }),
+
+    $test('getMetadata - action is update, store has record with version, new record has null version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: testVersion}, {version: undefined}, {version: undefined});
+    }),
+
+    $test('getMetadata - action is update, store has record with version, new record has no version')
+    .checkAsync(function () {
+        return verify_getMetadata('update', {version: testVersion}, {}, {version: testVersion});
+    }),
+
+    // getMetadata tests - action: delete
+
+    $test('getMetadata - action is delete, store has no such record')
+    .checkAsync(function () {
+        return verify_getMetadata('delete', undefined, {}, {});
+    }),
+
+    $test('getMetadata - action is delete, store has record with version')
+    .checkAsync(function () {
+        return verify_getMetadata('delete', {version: testVersion}, {}, {version: testVersion});
+    }),
+
+    $test('getMetadata - action is delete, store has record with null version')
+    .checkAsync(function () {
+        return verify_getMetadata('delete', {version: null}, {}, {version: null});
+    }),
+
+    $test('getMetadata - action is delete, store has record with no version')
+    .checkAsync(function () {
+        return verify_getMetadata('delete', {}, {}, {version: null});
+    }),
+
+    $test('getMetadata - action is delete, store has record with no version, specified record has version')
+    .description('verify that version passed to getMetadata is not used in case of a delete operation')
+    .checkAsync(function () {
+        return verify_getMetadata('delete', {}, {version: testVersion}, {version: null});
+    }),
+
+    $test('getOperationForInsertingLog')
+    .description('verify that getOperationForInsertingLog uses whatever metadata is returned by getMetadata()')
+    .checkAsync(function () {
+        return verify_getOperation(function(operationTableManager) {
+            return operationTableManager._getOperationForInsertingLog(storeTestHelper.testTableName, 'someaction', {id: testId});
+        }, function(operation) {
+            $assert.areEqual(operation, {
+                action: 'upsert',
+                tableName: operationTableName,
+                data: {
+                    id: 1,
+                    tableName: storeTestHelper.testTableName,
+                    action: 'someaction',
+                    itemId: testId,
+                    metadata: 'some-metadata'
+                }
+            });
+        });
+    }),
+
+    $test('getOperationForUpdatingLog')
+    .description('verify that getOperationForInsertingLog uses whatever metadata is returned by getMetadata()')
+    .checkAsync(function () {
+        return verify_getOperation(function(operationTableManager) {
+            return operationTableManager._getOperationForUpdatingLog(1, storeTestHelper.testTableName, 'someaction', {id: testId});
+        }, function(operation) {
+            $assert.areEqual(operation, {
+                action: 'upsert',
+                tableName: operationTableName,
+                data: {
+                    id: 1,
+                    action: 'someaction',
+                    metadata: 'some-metadata'
+                }
+            });
+        });
     })
 );
+
+function verify_getOperation(getOperation, verifyOperation) {
+    var operationTableManager = createOperationTableManager(store);
+    operationTableManager.getMetadata = function() {
+        return Platform.async(function(callback) {
+            callback();
+        })().then(function() {
+            return 'some-metadata';
+        });
+    };
+
+    return operationTableManager.initialize().then(function() {
+        return getOperation(operationTableManager);
+    }).then(function(result) {
+        verifyOperation(result);
+    }, function(error) {
+        $assert.fail(error);
+    });
+}
+
+function verify_getMetadata(action, existingRecord, record, expectedMetadata) {
+    var operationTableManager = createOperationTableManager(store);
+    
+    return operationTableManager.initialize().then(function() {
+        // Setup the local table
+        if (existingRecord) {
+            existingRecord.id = testId;
+            return store.upsert(storeTestHelper.testTableName, existingRecord);
+        }
+    }).then(function(result) {
+        // call getMetadata
+        record.id = testId; 
+        return operationTableManager.getMetadata(storeTestHelper.testTableName, action, record);
+    }).then(function(result) {
+        // verify result of getMetadata
+        expectedMetadata = expectedMetadata;
+        $assert.areEqual(result, expectedMetadata);
+    }, function(error) {
+        $assert.fail(error);
+    });
+}
 
 // Perform the specified actions and verify that the operation table has the expected operations
 function performActionsAndVerifySuccess(actions, expectedOperations) {
@@ -510,10 +710,9 @@ function performActionsAndVerifySuccess(actions, expectedOperations) {
 
 // Perform the specified setupActions and then verify that errorAction fails
 function performActionsAndVerifyError(setupActions, errorAction) {
-    var operationTableManager = createOperationTableManager(store),
-        itemId = 'abc';
+    var operationTableManager = createOperationTableManager(store);
 
-    return performActions(operationTableManager, testItem.id, setupActions).then(function() {
+    return performActions(operationTableManager, testItem, setupActions).then(function() {
         return performActions(operationTableManager, testItem.id, [errorAction]);
     }, function(error) {
         $assert.fail(error);
@@ -557,6 +756,7 @@ function verifyOperations(operationTableManager, itemId, expectedOperations) {
         for (var i in expectedOperations) {
             expectedOperations[i].tableName = storeTestHelper.testTableName;
             expectedOperations[i].itemId = itemId;
+            expectedOperations[i].metadata = expectedOperations[i].metadata || {};
         }
         
         $assert.areEqual(operations, expectedOperations);

--- a/sdk/test/tests/target/cordova/pull.tests.js
+++ b/sdk/test/tests/target/cordova/pull.tests.js
@@ -105,7 +105,7 @@ $testGroup('pull tests')
 
 function pullAndValidateSettings(settings, expectedPageSize) {
     client = client.withFilter( function(req, next, callback) {
-        $assert.areEqual(req.url, "http://someurl/tables/sometable?$filter=(updatedAt ge datetimeoffset'1969-12-31T08:00:00.000Z')&$orderby=updatedAt&$top=" + 
+        $assert.areEqual(req.url, "http://someurl/tables/todoitem?$filter=(updatedAt ge datetimeoffset'1969-12-31T08:00:00.000Z')&$orderby=updatedAt&$top=" + 
                         expectedPageSize + "&__includeDeleted=true");
         callback('someerror', 'response');
     });

--- a/sdk/test/tests/target/cordova/pushError.tests.js
+++ b/sdk/test/tests/target/cordova/pushError.tests.js
@@ -1,0 +1,180 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/**
+ * @file unit tests for the 'pushError' module
+ */
+
+var Platform = require('Platforms/Platform'),
+    Query = require('azure-query-js').Query,
+    tableConstants = require('../../../../src/constants').table,
+    storeTestHelper = require('./storeTestHelper'),
+    runner = require('../../../../src/Utilities/taskRunner'),
+    createOperationTableManager = require('../../../../src/sync/operations').createOperationTableManager,
+    createPushError = require('../../../../src/sync/pushError').createPushError,
+    MobileServiceSqliteStore = require('Platforms/MobileServiceSqliteStore');
+
+var operationTableName = tableConstants.operationTableName,
+    store,
+    testVersion = 'someversion',
+    testId = 'someid';
+    
+$testGroup('pushError tests')
+
+    // Clear the store before running each test.
+    .beforeEachAsync(function() {
+        return storeTestHelper.createEmptyStore().then(function(emptyStore) {
+            store = emptyStore;
+        });
+    }).tests(
+
+    $test('pushError.update()')
+    .description('verify update() uses whatever metadata is returned by operationTableManager.getMetadata()')
+    .checkAsync(function () {
+        var testId = 'someid',
+            operationTableManager = createOperationTableManager(store),
+            pushOperation = {
+                logRecord: {
+                    id: 101,
+                    tableName: storeTestHelper.testTableName,
+                    action: 'someaction',
+                    itemId: testId,
+                    metadata: {}
+                },
+                data: {
+                    id: testId
+                }
+            },
+            pushError = createPushError(store, operationTableManager, runner(), pushOperation, 'some-error');
+
+        var batchExecuted;
+        store.executeBatch = function(batch) {
+            return Platform.async(function(callback) {
+                $assert.areEqual(batch[0].data.metadata, 'some-metadata');
+                batchExecuted = true;
+                callback();
+            })();
+        };
+
+        operationTableManager.getMetadata = function() {
+            return Platform.async(function(callback) {
+                return callback(null, 'some-metadata');
+            })();
+        };
+
+        return pushError.update({ id: testId }).then(function() {
+            $assert.isTrue(batchExecuted);
+        });
+    }),
+
+    // changeAction(insert) tests
+    $test('pushError.changeAction() - new action is insert, new record value specifies version')
+    .checkAsync(function () {
+        return verifyChangeAction('update', 'insert', testId, testId, undefined, testVersion, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is insert, new record value specifies different ID')
+    .checkAsync(function () {
+        return verifyChangeAction('update', 'insert', testId, 'changed id', testVersion, testVersion, false);
+    }),
+
+    $test('pushError.changeAction() - new action is insert, new record value not specified, old action is update')
+    .checkAsync(function () {
+        return verifyChangeAction('update', 'insert', testId, undefined, testVersion, undefined, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is insert, new record value not specified, old action is delete')
+    .checkAsync(function () {
+        return verifyChangeAction('delete', 'insert', testId, undefined, testVersion, undefined, false);
+    }),
+
+    // changeAction(update) tests
+    $test('pushError.changeAction() - new action is update, new record value specifies version')
+    .checkAsync(function () {
+        return verifyChangeAction('insert', 'update', testId, testId, undefined, testVersion, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is update, new record value specifies different ID')
+    .checkAsync(function () {
+        return verifyChangeAction('update', 'update', testId, 'changed id', testVersion, testVersion, false);
+    }),
+
+    $test('pushError.changeAction() - new action is update, new record value not specified, old action is insert')
+    .checkAsync(function () {
+        return verifyChangeAction('insert', 'update', testId, undefined, testVersion, undefined, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is update, new record value not specified, old action is delete')
+    .checkAsync(function () {
+        return verifyChangeAction('delete', 'update', testId, undefined, testVersion, undefined, false);
+    }),
+
+    // changeAction(delete) tests
+    $test('pushError.changeAction() - new action is delete, new record value specifies version')
+    .checkAsync(function () {
+        return verifyChangeAction('insert', 'delete', testId, testId, undefined, testVersion, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is delete, new record value specifies different ID')
+    .checkAsync(function () {
+        return verifyChangeAction('update', 'delete', testId, 'changed id', testVersion, testVersion, false);
+    }),
+
+    $test('pushError.changeAction() - new action is delete, new record value not specified, old action is insert')
+    .checkAsync(function () {
+        return verifyChangeAction('insert', 'delete', testId, undefined, testVersion, undefined, true, testVersion);
+    }),
+
+    $test('pushError.changeAction() - new action is update, new record value not specified, old action is delete')
+    .checkAsync(function () {
+        return verifyChangeAction('delete', 'update', testId, undefined, testVersion, undefined, false);
+    })
+);
+
+function verifyChangeAction(oldAction, newAction, oldItemId, newItemId, oldVersion, newVersion, isSuccessExpected, expectedVersion) {
+    var testId = 'someid',
+        operationTableManager = createOperationTableManager(store),
+        pushOperation = {
+            logRecord: {
+                id: 101,
+                tableName: storeTestHelper.testTableName,
+                action: oldAction,
+                itemId: oldItemId,
+                metadata: { version: oldVersion }
+            },
+            data: {
+                id: oldItemId
+                // version not set intentionally. we want to make sure the test succeeds by using the version value in the new record.
+            }
+        },
+        pushError = createPushError(store, operationTableManager, runner(), pushOperation, 'some-error');
+
+    var batchExecuted;
+    store.executeBatch = function(batch) {
+        return Platform.async(function(callback) {
+            batchExecuted = batch;
+            callback();
+        })();
+    };
+
+    var newRecord;
+    if (newItemId) {
+        newRecord = {id: newItemId, version: newVersion};
+    }
+    return pushError.changeAction(newAction, newRecord).then(function() {
+        $assert.isTrue(isSuccessExpected);
+        // 0th operation in the batch modifies the log record
+        $assert.areEqual(batchExecuted[0].data.metadata.version, expectedVersion);
+        $assert.areEqual(batchExecuted[0].data.action, newAction);
+
+        // 1st operation in the batch modifies the data in the local table
+        if (newAction === 'delete') {
+            $assert.areEqual(batchExecuted.length, 2);
+            $assert.areEqual(batchExecuted[1].action, 'delete');
+        }
+    }, function(error) {
+        $assert.isNull(batchExecuted);
+        $assert.isFalse(isSuccessExpected);
+    });
+}

--- a/sdk/test/tests/target/cordova/storeTestHelper.js
+++ b/sdk/test/tests/target/cordova/storeTestHelper.js
@@ -12,7 +12,7 @@ var Platform = require('Platforms/Platform'),
     MobileServiceSqliteStore = require('Platforms/MobileServiceSqliteStore'),
     operationTableName = require('../../../../src/constants').table.operationTableName,
     pulltimeTableName = require('../../../../src/constants').table.pulltimeTableName,
-    testTableName = 'sometable',
+    testTableName = 'todoitem',
     testDbFile = 'somedbfile.db',
     store;
 


### PR DESCRIPTION
This PR closes https://github.com/Azure/azure-mobile-apps-js-client/issues/179.

Root cause of the bug is that the push operation does not pass the version information and hence a conflict is never detected.

This PR stores the version information in a metadata column in the operation table. This way we can retrieve the version of a deleted record while performing a push.