### PR TITLE
Change onConflict() to only pass pushError as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Changes are pushed to the server, one change at a time. Pushing a change can res
 Here is how you register a push handler:
 ```
 syncContext.pushHandler = {
-    onConflict: function (serverRecord, clientRecord, pushError) {
+    onConflict: function (pushError) {
         // Handle the conflict
     },
     onError: function (pushError) {
@@ -136,11 +136,15 @@ syncContext.pushHandler = {
 };
 ```
 
-The `onConflict` callback passes the values of the server and client records at the time of push. Note that `serverRecord` is provided only for convenience, and _may not be always available_ based on the kind of conflict. Specifically, `serverRecord` will not be available when the server inserts or deletes a record and the client inserts a record with the same ID. This should be rare if you use GUIDs for IDs. The `pushError` object contains details of the error and has helper methods for resolving the conflict.
+The `pushError` object contains all the details of the error / conflict and has helper methods to resolve it.
 
 _Informational methods:_
 
 `pushError` provides the following informational methods:
+
+* `getServerRecord()`  - Get the value of the record on the server. Note that the server value will not be available in the _onError_ callback and _may not be always available_ in the _onConflict_ callback depending on the kind of conflict. Specifically, the server value will not be available when the server inserts or deletes a record and the client inserts a record with the same ID. This should be rare if you use GUIDs for IDs.
+
+* `getClientRecord()`  - Get the value of the record that was attempted to be pushed from the client to server 
 
 * `getError()`  - Get the detailed underlying error that caused the push to fail
 

--- a/sdk/src/sync/MobileServiceSyncContext.js
+++ b/sdk/src/sync/MobileServiceSyncContext.js
@@ -214,7 +214,7 @@ function MobileServiceSyncContext(client) {
      * 
      * Error handling is delegated to the pushHandler property of MobileServiceSyncContext instance.
      * The pushHandler is an object with the following property:
-     * - function onConflict (serverRecord, clientRecord, pushError) - this is called when a conflict is encountered while pushing a record to the server.
+     * - function onConflict (pushError) - this is called when a conflict is encountered while pushing a record to the server.
      * - function onError (pushError) - this is called when an error is encountered while pushing a record to the server.
      * 
      * @returns A promise that is fulfilled when all pending operations are pushed OR is rejected if the push fails or is cancelled.  

--- a/sdk/src/sync/pushError.js
+++ b/sdk/src/sync/pushError.js
@@ -318,7 +318,7 @@ function handlePushError(pushError, pushHandler) {
         if (pushError.isConflict()) {
             if (pushHandler && pushHandler.onConflict) {
                 // NOTE: value of server record will not be available in case of 409.
-                return pushHandler.onConflict(pushError.getServerRecord(), pushError.getClientRecord(), pushError);
+                return pushHandler.onConflict(pushError);
             }
         } else if (pushHandler && pushHandler.onError) {
             return pushHandler.onError(pushError);

--- a/sdk/test/tests/target/cordova/offline.functional.tests.js
+++ b/sdk/test/tests/target/cordova/offline.functional.tests.js
@@ -223,12 +223,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 409);
             
-            return table.lookup(clientRecord.id).then(function(serverValue) {
-                return pushError.changeAction('update');
-            });
+            return pushError.changeAction('update');
         };
         
         var actions = [
@@ -266,10 +264,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.update(newValue);
         };
         
@@ -360,10 +358,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.update(newValue);
         };
         
@@ -387,10 +385,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.cancelAndUpdate(newValue).then(function() {
                 // We are going to push twice. We want pushHandler to be used only the first time.
                 syncContext.pushHandler = undefined;
@@ -436,10 +434,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.cancelAndDiscard(newValue).then(function() {
                 // We are going to push twice. We want pushHandler to be used only the first time.
                 syncContext.pushHandler = undefined;
@@ -490,10 +488,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.update(newValue);
         };
         
@@ -624,10 +622,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.cancelAndDiscard(newValue).then(function() {
                 pushError.isHandled = false;
             });
@@ -665,10 +663,10 @@ $testGroup('offline functional tests')
     .checkAsync(function () {
         
         syncContext.pushHandler = {};
-        syncContext.pushHandler.onConflict = function (serverRecord, clientRecord, pushError) {
+        syncContext.pushHandler.onConflict = function (pushError) {
             $assert.areEqual(pushError.getError().request.status, 412);
-            var newValue = clientRecord;
-            newValue.version = serverRecord.version;
+            var newValue = pushError.getClientRecord();
+            newValue.version = pushError.getServerRecord().version;
             return pushError.cancelAndDiscard(newValue).then(function() {
                 throw 'some error';
             });


### PR DESCRIPTION
- serverRecord and clientRecord values can be obtained from pushError using pushError.getServerRecord() and pushError.getClientRecord() respectively.