### PR TITLE
Fix buggy target / platform check

### DIFF
--- a/sdk/src/Platform/environment.js
+++ b/sdk/src/Platform/environment.js
@@ -1,0 +1,21 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+// Module to retrieve environment details
+
+/**
+ * Gets details of the target
+ * @private
+ * 
+ * @return 'Cordova', 'Web' or 'Unknown'
+ */
+exports.getTarget = function() {
+    if (typeof global !== 'undefined' && global.cordova && global.cordova.version) {
+        return 'Cordova';
+    } else if (typeof global !== 'undefined') {
+        return 'Web';
+    } else {
+        return 'Unknown';
+    }
+};

--- a/sdk/src/Platform/index.js
+++ b/sdk/src/Platform/index.js
@@ -2,9 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
+var target = require('./environment').getTarget();
 
-if (window && window.cordova && window.cordova.version) {
+if (environment.getTarget() === 'Cordova') {
     module.exports = require('./cordova');
-} else {
+} else if (environment.getTarget() === 'Web') {
     module.exports = require('./web');
+} else {
+    throw new Error('Unsupported target');
 }

--- a/sdk/src/Platform/web/index.js
+++ b/sdk/src/Platform/web/index.js
@@ -142,8 +142,6 @@ exports.getOperatingSystemInfo = function () {
 };
 
 exports.getSdkInfo = function () {
-    var isCordovaEnvironment = window && window.cordova && window.cordova.version;
-
     return {
         language: environment.getTarget(),
         fileVersion: version

--- a/sdk/src/Platform/web/index.js
+++ b/sdk/src/Platform/web/index.js
@@ -10,6 +10,7 @@ var _ = require('../../Utilities/Extensions'),
     Promises = require('../../Utilities/Promises'),
     version = require('../../../../package.json').version,
     resources = require('../../resources.json'),
+    environment = require('../environment'),
     inMemorySettingStore = {};
 
 try {
@@ -144,7 +145,7 @@ exports.getSdkInfo = function () {
     var isCordovaEnvironment = window && window.cordova && window.cordova.version;
 
     return {
-        language: isCordovaEnvironment ? "Cordova" : "Web",
+        language: environment.getTarget(),
         fileVersion: version
     };
 };


### PR DESCRIPTION
- Changed 'window' to 'global' to be able to run in nodejs context. Browserify defines global, so this work just fine even in standalone bundles.
- Check for the presence of 'global' using typeof
- Fixes https://github.com/Azure/azure-mobile-apps-js-client/issues/191