### PR TITLE
Change the way store deletes rows specified by a query

### DIFF
--- a/sdk/test/tests/target/cordova/purge.tests.js
+++ b/sdk/test/tests/target/cordova/purge.tests.js
@@ -69,6 +69,33 @@ $testGroup('purge tests')
         return testHelper.runActions(actions);
     }),
 
+    $test('Vanilla purge - purge query matching entire table where table has too many records')
+    .checkAsync(function () {
+        var records = [],
+            tableQuery = new Query(tableName),
+            purgeQuery = tableQuery;
+
+        for (var i = 0; i < 3000; i++) {
+            records.push({id: 'id'+i, text: 'sometext'});
+        }
+
+        var actions = [
+            // Add record and incremental state
+            [store, store.upsert, tableName, records],
+            addIncrementalSyncState,
+            // Perform purge
+            [purgeManager, purgeManager.purge, purgeQuery],
+            // Verify purge
+            verifyIncrementalSyncStateIsRemoved,
+            [store, store.read, tableQuery],
+            function(result) {
+                $assert.areEqual(result, []);
+            }
+        ];
+
+        return testHelper.runActions(actions);
+    }),
+
     $test('Vanilla purge - purge query not matching all records')
     .checkAsync(function () {
         var record1 = {id: '1', text: 'a'},

--- a/sdk/test/tests/target/cordova/pushError.tests.js
+++ b/sdk/test/tests/target/cordova/pushError.tests.js
@@ -18,6 +18,11 @@ var Platform = require('../../../../src/Platform'),
 var operationTableName = tableConstants.operationTableName,
     store,
     testVersion = 'someversion',
+    testError = {
+        request: {
+            status: 400
+        }
+    },
     testId = 'someid';
     
 $testGroup('pushError tests')
@@ -105,7 +110,7 @@ $testGroup('pushError tests')
                     id: testId
                 }
             },
-            pushError = createPushError(store, operationTableManager, runner(), pushOperation, 'some-error');
+            pushError = createPushError(store, operationTableManager, runner(), pushOperation, testError);
 
         var batchExecuted;
         store.executeBatch = function(batch) {
@@ -207,7 +212,7 @@ function verifyChangeAction(oldAction, newAction, oldItemId, newItemId, oldVersi
                 // version not set intentionally. we want to make sure the test succeeds by using the version value in the new record.
             }
         },
-        pushError = createPushError(store, operationTableManager, runner(), pushOperation, 'some-error');
+        pushError = createPushError(store, operationTableManager, runner(), pushOperation, testError);
 
     var batchExecuted;
     store.executeBatch = function(batch) {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-mobile-apps-js-client/issues/232

- Enumerating records in a table matching the specified query and then deleting them is problematic for multiple reasons. Poor perf is one, but more importantly the generated statement may exceed the max allowed number of sql variables.
- Changed the implementation to use a nested select instead.

