### PR TITLE
Minor correction to how we return error

### DIFF
--- a/sdk/src/LoginUis/CordovaPopup.js
+++ b/sdk/src/LoginUis/CordovaPopup.js
@@ -54,7 +54,7 @@ exports.login = function (startUri, endUri, callback) {
                         loginWindow.close();
                     }, 500);
                     var result = parseOAuthResultFromDoneUrl(evt.url);
-                    callback(new Error(result.error), result.oAuthToken);
+                    callback(result.error, result.oAuthToken);
                 }
             };
 
@@ -104,7 +104,7 @@ function parseOAuthResultFromDoneUrl(url) {
         errorMessage = extractMessageFromUrl(url, "#error=");
     return {
         oAuthToken: successMessage ? JSON.parse(successMessage) : null,
-        error: errorMessage
+        error: errorMessage ? new Error(errorMessage) : null
     };
 }
 


### PR DESCRIPTION
- An earlier commit made a change to return Error objects instead of error strings.
- However, it caused a regression as it did not check if errorMessage is empty before returning an Error instance.
- With this change, an Error object will be returned only if the error string is non-empty.