### PR TITLE
Changes for browser-based login

### DIFF
--- a/sdk/src/LoginUis/BrowserPopup.js
+++ b/sdk/src/LoginUis/BrowserPopup.js
@@ -11,7 +11,7 @@ exports.supportsCurrentRuntime = function () {
     return true;
 };
 
-exports.login = function (startUri, endUri, callback) {
+exports.login = function (options, callback) {
     /// <summary>
     /// Displays the login UI and calls back on completion
     /// </summary>
@@ -21,15 +21,15 @@ exports.login = function (startUri, endUri, callback) {
     // is validated against whitelist on the server; we are only supplying this
     // origin to indicate *which* of the whitelisted origins to use).
     var completionOrigin = PostMessageExchange.getOriginRoot(window.location.href),
-        runtimeOrigin = PostMessageExchange.getOriginRoot(startUri),
+        runtimeOrigin = PostMessageExchange.getOriginRoot(options.startUri),
         // IE does not support popup->opener postMessage calls, so we have to
         // route the message via an iframe
         useIntermediateIframe = window.navigator.userAgent.indexOf("MSIE") >= 0 || window.navigator.userAgent.indexOf("Trident") >= 0,
         intermediateIframe = useIntermediateIframe && createIntermediateIframeForLogin(runtimeOrigin, completionOrigin),
         completionType = useIntermediateIframe ? "iframe" : "postMessage";
 
-    startUri += startUri.indexOf('?') == -1 ? '?' : '&';
-    startUri += "completion_type=" + completionType + "&completion_origin=" + encodeURIComponent(completionOrigin);
+    options.startUri += options.startUri.indexOf('?') == -1 ? '?' : '&';
+    options.startUri += "completion_type=" + completionType + "&completion_origin=" + encodeURIComponent(completionOrigin);
 
     // Browsers don't allow postMessage to a file:// URL (except by setting origin to "*", which is unacceptable)
     // so abort the process early with an explanation in that case.
@@ -39,7 +39,7 @@ exports.login = function (startUri, endUri, callback) {
         return;
     }
 
-    var loginWindow = window.open(startUri, "_blank", "location=no,resizable=yes"),
+    var loginWindow = window.open(options.startUri, "_blank", "location=no,resizable=yes"),
         complete = function(errorValue, oauthValue) {
             // Clean up event handlers, windows, frames, ...
             window.clearInterval(checkForWindowClosedInterval);

--- a/sdk/src/LoginUis/CordovaPopup.js
+++ b/sdk/src/LoginUis/CordovaPopup.js
@@ -2,10 +2,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-// Note: Cordova is PhoneGap.
-// This login UI implementation uses the InAppBrowser plugin,
-// to install the plugin use the following command
-//   cordova plugin add org.apache.cordova.inappbrowser
+var config = require('../config');
 
 var requiredCordovaVersion = { major: 3, minor: 0 };
 
@@ -19,59 +16,6 @@ exports.supportsCurrentRuntime = function () {
     return !!currentCordovaVersion() && !isRunUnderRippleEmulator();
 };
 
-exports.login = function (startUri, endUri, callback) {
-    /// <summary>
-    /// Displays the login UI and calls back on completion
-    /// </summary>
-
-    // Ensure it's a sufficiently new version of Cordova, and if not fail synchronously so that
-    // the error message will show up in the browser console.
-    var foundCordovaVersion = currentCordovaVersion(),
-        message;
-
-    if (!isSupportedCordovaVersion(foundCordovaVersion)) {
-        message = "Not a supported version of Cordova. Detected: " + foundCordovaVersion +
-                    ". Required: " + requiredCordovaVersion.major + "." + requiredCordovaVersion.minor;
-        throw new Error(message);
-    }
-    if (!hasInAppBrowser) {
-        message = 'A required plugin: "org.apache.cordova.inappbrowser" was not detected.';
-        throw new Error(message);
-    }
-
-    // Initially we show a page with a spinner. This stays on screen until the login form has loaded.
-    var redirectionScript = "<script>location.href = unescape('" + window.escape(startUri) + "')</script>",
-        startPage = "data:text/html," + encodeURIComponent(getSpinnerMarkup() + redirectionScript);
-
-    // iOS inAppBrowser issue requires this wrapping
-    setTimeout(function () {
-        var loginWindow = window.open(startPage, "_blank", "location=no,hardwareback=no"),
-            flowHasFinished = false,
-            loadEventHandler = function (evt) {
-                if (!flowHasFinished && evt.url.indexOf(endUri) === 0) {
-                    flowHasFinished = true;
-                    setTimeout(function () {
-                        loginWindow.close();
-                    }, 500);
-                    var result = parseOAuthResultFromDoneUrl(evt.url);
-                    callback(result.error, result.oAuthToken);
-                }
-            };
-
-        // Ideally we'd just use loadstart because it happens earlier, but it randomly skips
-        // requests on iOS, so we have to listen for loadstop as well (which is reliable).
-        loginWindow.addEventListener('loadstart', loadEventHandler);
-        loginWindow.addEventListener('loadstop', loadEventHandler);
-
-        loginWindow.addEventListener('exit', function (evt) {
-            if (!flowHasFinished) {
-                flowHasFinished = true;
-                callback(new Error("UserCancelled"), null);
-            }
-        });
-    }, 500);
-};
-
 function isRunUnderRippleEmulator () {
     // Returns true when application runs under Ripple emulator 
     return window.parent && !!window.parent.ripple;
@@ -83,64 +27,12 @@ function currentCordovaVersion() {
     return window.cordova && window.cordova.version;
 }
 
-function isSupportedCordovaVersion(version) {
-    var versionParts = currentCordovaVersion().match(/^(\d+).(\d+)./);
-    if (versionParts) {
-        var major = Number(versionParts[1]),
-            minor = Number(versionParts[2]),
-            required = requiredCordovaVersion;
-        return (major > required.major) ||
-               (major === required.major && minor >= required.minor);
+// Optional callback accepting (error, user) parameters.
+exports.login = function (options, callback) {
+    var configuration = config.get();
+    if (configuration && configuration.login && configuration.login.loginWithOptions) {
+        return configuration.login.loginWithOptions(options, callback);
     }
-    return false;
-}
 
-function hasInAppBrowser() {
-    return !window.open;
-}
-
-function parseOAuthResultFromDoneUrl(url) {
-    var successMessage = extractMessageFromUrl(url, "#token="),
-        errorMessage = extractMessageFromUrl(url, "#error=");
-    return {
-        oAuthToken: successMessage ? JSON.parse(successMessage) : null,
-        error: errorMessage ? new Error(errorMessage) : null
-    };
-}
-
-function extractMessageFromUrl(url, separator) {
-    var pos = url.indexOf(separator);
-    return pos < 0 ? null : decodeURIComponent(url.substring(pos + separator.length));
-}
-
-function getSpinnerMarkup() {
-    // The default InAppBrowser experience isn't ideal, as it just shows the user a blank white screen
-    // until the login form appears. This might take 10+ seconds during which it looks broken.
-    // Also on iOS it's possible for the InAppBrowser to initially show the results of the *previous*
-    // login flow if the InAppBrowser was dismissed before completion, which is totally undesirable.
-    // To fix both of these problems, we display a simple "spinner" graphic via a data: URL until
-    // the current login screen has loaded. We generate the spinner via CSS rather than referencing
-    // an animated GIF just because this makes the client library smaller overall.
-    var vendorPrefix = "webkitTransform" in document.documentElement.style ? "-webkit-" : "",
-        numSpokes = 12,
-        spokesMarkup = "";
-    for (var i = 0; i < numSpokes; i++) {
-        spokesMarkup += "<div style='-prefix-transform: rotateZ(" + (180 + i * 360 / numSpokes) + "deg);" +
-                                    "-prefix-animation-delay: " + (0.75 * i / numSpokes) + "s;'></div>";
-    }
-    return [
-        "<!DOCTYPE html><html>",
-        "<head><meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1'></head>",
-        "<body><div id='spinner'>" + spokesMarkup + "</div>",
-        "<style type='text/css'>",
-        "    #spinner { position: absolute; top: 50%; left: 50%; -prefix-animation: spinner 10s linear infinite; }",
-        "    #spinner > div {",
-        "        background: #333; opacity: 0; position: absolute; top: 11px; left: -2px; width: 4px; height: 21px; border-radius: 2px;",
-        "        -prefix-transform-origin: 50% -11px; -prefix-animation: spinner-spoke 0.75s linear infinite;",
-        "    }",
-        "    @-prefix-keyframes spinner { 0% { -prefix-transform: rotateZ(0deg); } 100% { -prefix-transform: rotateZ(-360deg); } }",
-        "    @-prefix-keyframes spinner-spoke { 0% { opacity: 0; } 5% { opacity: 1; } 70% { opacity: 0; } 100% { opacity: 0; } }",
-        "</style>",
-        "</body></html>"
-    ].join("").replace(/-prefix-/g, vendorPrefix);
-}
+    callback(new Error('Cordova login implementation not provided!'));
+};

--- a/sdk/src/LoginUis/WebAuthBroker.js
+++ b/sdk/src/LoginUis/WebAuthBroker.js
@@ -13,7 +13,7 @@ exports.supportsCurrentRuntime = function () {
     return isWebAuthBrokerAvailable();
 };
 
-exports.login = function (startUri, endUri, callback) {
+exports.login = function (options, callback) {
     /// <summary>
     /// Displays the login UI and calls back on completion
     /// </summary>
@@ -87,24 +87,24 @@ exports.login = function (startUri, endUri, callback) {
     // be registered with the Microsoft Azure Mobile Service, but it provides a better 
     // experience as HTTP cookies are supported so that users do not have to
     // login in everytime the application is launched.
-    if (endUri) {
-        endUri = new Windows.Foundation.Uri(endUri);
+    if (options.endUri) {
+        options.endUri = new Windows.Foundation.Uri(options.endUri);
     } else {
         var ssoQueryParameter = {},
             redirectUri = windowsWebAuthBroker.getCurrentApplicationCallbackUri().absoluteUri;
 
         ssoQueryParameter[easyAuthRedirectUriKey] = redirectUri;
-        startUri = _.url.combinePathAndQuery(startUri, _.url.getQueryString(ssoQueryParameter));
+        options.startUri = _.url.combinePathAndQuery(options.startUri, _.url.getQueryString(ssoQueryParameter));
     }
     
-    startUri = new Windows.Foundation.Uri(startUri);
+    options.startUri = new Windows.Foundation.Uri(options.startUri);
     
     // If authenticateAndContinue method is available, we should use it instead of authenticateAsync.
     // In the event that it exists, but fails (which is the case with Win 10), we fallback to authenticateAsync.
     var isLoginWindowLaunched;
     try {
         WinJS.Application.addEventListener('activated', webAuthBrokerContinuationCallback, true);
-        windowsWebAuthBroker.authenticateAndContinue(startUri, endUri);
+        windowsWebAuthBroker.authenticateAndContinue(options.startUri, options.endUri);
 
         isLoginWindowLaunched = true;
     } catch (ex) {
@@ -112,7 +112,7 @@ exports.login = function (startUri, endUri, callback) {
     }
 
     if (!isLoginWindowLaunched) {
-        windowsWebAuthBroker.authenticateAsync(noneWebAuthOptions, startUri, endUri)
+        windowsWebAuthBroker.authenticateAsync(noneWebAuthOptions, options.startUri, options.endUri)
         .done(webAuthBrokerSuccessCallback, webAuthBrokerErrorCallback);
     }
 };

--- a/sdk/src/Platform/web/index.js
+++ b/sdk/src/Platform/web/index.js
@@ -148,17 +148,17 @@ exports.getSdkInfo = function () {
     };
 };
 
-exports.login = function (startUri, endUri, callback) {
+exports.login = function (options, callback) {
     // Force logins to go over HTTPS because the runtime is hardcoded to redirect
     // the server flow back to HTTPS, and we need the origin to match.
     var findProtocol = /^[a-z]+:/,
         requiredProtocol = 'https:';
-    startUri = startUri.replace(findProtocol, requiredProtocol);
-    if (endUri) {
-        endUri = endUri.replace(findProtocol, requiredProtocol);
+    options.startUri = options.startUri.replace(findProtocol, requiredProtocol);
+    if (options.endUri) {
+        options.endUri = options.endUri.replace(findProtocol, requiredProtocol);
     }
 
-    return getBestProvider(knownLoginUis).login(startUri, endUri, callback);
+    return getBestProvider(knownLoginUis).login(options, callback);
 };
 
 exports.toJson = function (value) {

--- a/sdk/src/config.js
+++ b/sdk/src/config.js
@@ -1,0 +1,20 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+// Module to hold custom configuration provided by users of the library.
+
+var configuration;
+
+function set(config) {
+    configuration = config;
+}
+
+function get() {
+    return configuration;
+}
+
+module.exports = {
+    set: set,
+    get: get
+};

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -2,7 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-var _ = require('./Utilities/Extensions');
+var _ = require('./Utilities/Extensions'),
+    config = require('./config');
+
+function configure(configuration) {
+    config.set(configuration);
+}
 
 /**
  * This module is the entry point for the _Azure Mobile Apps Javascript client SDK_. 
@@ -37,7 +42,9 @@ var api = { // Modules that need to be exposed outside the SDK for all targets
     /** 
      * @type {QueryJs}
      */
-    Query: require('azure-query-js').Query
+    Query: require('azure-query-js').Query,
+
+    configure: configure
 };
 
 // Target (i.e. Cordova / Browser / etc) specific definitions that need to be exposed outside the SDK


### PR DESCRIPTION
- MobileServiceLogin.js changes how it passes parameters to Platform.login(). Instead of passing the startUri and the endUri, it now passes an object. Different login implementations use different properties from the object for their working.
- CordovaPopup implementation has been changed not to use the InAppBrowser. Instead, it simply delegates the login work to config.login.loginWithOptions(). This method is implemented by the Cordova plugin using native (iOS / Android) implementations. Attempting to perform a login without this method will simply fail.