### PR TITLE
Made the version header test less pedantic on the version

### DIFF
--- a/sdk/test/tests/shared/mobileServicesClient._request.js
+++ b/sdk/test/tests/shared/mobileServicesClient._request.js
@@ -114,11 +114,11 @@ $testGroup('MobileServiceClient._request',
                 isCordova = Platform.getSdkInfo().language === "Cordova";
 
             if (isWinJs) {
-                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=WinJS; os=Windows 8; os_version=--; arch=Neutral; version=2.0.0-beta"));
+                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=WinJS; os=Windows 8; os_version=--; arch=Neutral; version=2.0"));
             } else if (isCordova) {
-                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=Cordova; os=--; os_version=--; arch=--; version=2.0.0-beta"));
+                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=Cordova; os=--; os_version=--; arch=--; version=2.0"));
             } else {
-                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=Web; os=--; os_version=--; arch=--; version=2.0.0-beta"));
+                $assert.areEqual(0, req.headers['X-ZUMO-VERSION'].indexOf("ZUMO/2.0 (lang=Web; os=--; os_version=--; arch=--; version=2.0"));
             }
             callback(null, { status: 200, responseText: null });
         });


### PR DESCRIPTION
Fixes #229.  The old test used version=2.0.0-beta, which means that as the version increases, you have to change this test every time.  The new test checks up to 2.0, so it lasts as long as the SDK version is not major-revved.

This unit test now passes on web.