### PR TITLE
Split tests into individual unit tests and corrected default case error

### DIFF
--- a/sdk/src/Utilities/Extensions.js
+++ b/sdk/src/Utilities/Extensions.js
@@ -578,6 +578,7 @@ exports.createError = function (exceptionOrMessage, request) {
     /// <returns>An object with error details</returns>
 
     var error;
+
     if (request) {
         var message = Platform.getResourceString("Extensions_DefaultErrorMessage");
 
@@ -610,9 +611,7 @@ exports.createError = function (exceptionOrMessage, request) {
                 if (isText) {
                     message = request.responseText;
                 } else {
-                    message =
-                        request.statusText ||
-                        Platform.getResourceString("Extensions_DefaultErrorMessage");
+                    message = request.statusText || Platform.getResourceString("Extensions_DefaultErrorMessage");
                 }
             }
         }
@@ -623,11 +622,9 @@ exports.createError = function (exceptionOrMessage, request) {
         error = new Error(exceptionOrMessage);
     } else if (exceptionOrMessage instanceof Error) { // If exceptionOrMessage is an Error object, use it as-is
         error = exceptionOrMessage; 
-    } else if (!_.isNull(exceptionOrMessage)) {
-        // Otherwise we'll use the object as an exception and leave the
-        // default error message
+    } else {
         error = new Error(Platform.getResourceString("Extensions_DefaultErrorMessage"));
-        error.exception = exceptionOrMessage;
+        if (!_.isNull(exceptionOrMessage)) error.exception = exceptionOrMessage;
     }
 
     return error;

--- a/sdk/test/tests/shared/extensions.js
+++ b/sdk/test/tests/shared/extensions.js
@@ -388,45 +388,68 @@ $testGroup('Extensions.js',
         }
     }),
 
-    $test('createError')
-    .description('Verify the creation of error messages')
+    $test('createError-empty')
+    .description('Verify the creation of error messages - empty')
     .check(function () {
         // Default
         var error = Extensions.createError();
         $assert.areEqual(error.message, 'Unexpected failure.');
         $assert.isNull(error.request);
         $assert.isNull(error.exception);
+    }),
 
-        // String
+    $test('createError-string')
+    .description('Verify the creation of error messages - string')
+    .check(function () {
         error = Extensions.createError('BOOM');
         $assert.areEqual(error.message, 'BOOM');
         $assert.isNull(error.request);
         $assert.isNull(error.exception);
+    }),
 
+    $test('createError-object')
+    .description('Verify the creation of error messages - object')
+    .check(function () {
         // Object
         error = Extensions.createError({ x: 123 });
         $assert.areEqual(error.message, 'Unexpected failure.');
         $assert.isNull(error.request);
         $assert.areEqual(error.exception.x, 123);
+    }),
 
+    $test('createError-errbody')
+    .description('Verify the creation of error messages - error in body')
+    .check(function () {
         // Failing request (error in body)
         error = Extensions.createError(null, { status: 400, responseText: '{"error":"BOOM"}'});
         $assert.areEqual(error.message, 'BOOM');
         $assert.areEqual(error.request.status, 400);
         $assert.isNull(error.exception);
+    }),
 
+    $test('createError-descbody')
+    .description('Verify the creation of error messages - description in body')
+    .check(function () {
         // Failing request (description in body)
         error = Extensions.createError(null, { status: 400, responseText: '{"description":"BOOM"}' });
         $assert.areEqual(error.message, 'BOOM');
         $assert.areEqual(error.request.status, 400);
         $assert.isNull(error.exception);
+    }),
 
+    $test('createError-statustext')
+    .description('Verify the creation of error messages - status text')
+    .check(function () {
         // Failing request (statusText)
         error = Extensions.createError(null, { status: 400, responseText: '{"other":"BOOM"}', statusText: 'EXPLODED' });
         $assert.areEqual(error.message, 'EXPLODED');
         $assert.areEqual(error.request.status, 400);
         $assert.isNull(error.exception);
+    }),
 
+    $test('createError-failingconn')
+    .description('Verify the creation of error messages - failing connection')
+    .check(function () {
         // Failing connection
         error = Extensions.createError(null, { status: 0, responseText: '{"description":"BOOM"}' });
         $assert.areEqual(error.message, 'Unexpected connection failure.');


### PR DESCRIPTION
Fixes #228 

Split the extensions createError test into several tests - otherwise we can't tell which one was actually failing.

createError() did not have a default case.  In this situation, the fall through would return null instead of an Error() object.  A default Error() object is now returned (which was the intent)