### PR TITLE
[Cordova] Fix OAuth requests rejection for Google provider

### DIFF
--- a/sdk/src/LoginUis/CordovaPopup.js
+++ b/sdk/src/LoginUis/CordovaPopup.js
@@ -19,7 +19,7 @@ exports.supportsCurrentRuntime = function () {
     return !!currentCordovaVersion() && !isRunUnderRippleEmulator();
 };
 
-exports.login = function (startUri, endUri, callback) {
+exports.login = function (startUri, endUri, callback, providerName, appUrl) {
     /// <summary>
     /// Displays the login UI and calls back on completion
     /// </summary>
@@ -34,8 +34,18 @@ exports.login = function (startUri, endUri, callback) {
                     ". Required: " + requiredCordovaVersion.major + "." + requiredCordovaVersion.minor;
         throw new Error(message);
     }
+
+    if (providerName === 'google') {
+        loginWithGoogle(appUrl, callback);
+    } else {
+        loginWithInAppBrowser(startUri, endUri, callback);
+    }
+};
+
+function loginWithInAppBrowser(startUri, endUri, callback) {
+
     if (!hasInAppBrowser) {
-        message = 'A required plugin: "org.apache.cordova.inappbrowser" was not detected.';
+        var message = 'A required plugin: "org.apache.cordova.inappbrowser" was not detected.';
         throw new Error(message);
     }
 
@@ -70,7 +80,20 @@ exports.login = function (startUri, endUri, callback) {
             }
         });
     }, 500);
-};
+}
+
+function loginWithGoogle(appUrl, callback) {
+
+    var successCallback = function (token) {
+        callback(null, token);
+    };
+
+    var errorCallback = function (errorResponse) {
+        callback(new Error(errorResponse), null);
+    };
+
+    cordova.exec(successCallback, errorCallback, "MobileServices", "loginWithGoogle", [appUrl])
+}
 
 function isRunUnderRippleEmulator () {
     // Returns true when application runs under Ripple emulator 

--- a/sdk/src/MobileServiceLogin.js
+++ b/sdk/src/MobileServiceLogin.js
@@ -449,7 +449,10 @@ function loginWithLoginControl(login, provider, useSingleSignOn, parameters, cal
         function (error, mobileServiceToken) {
             login._loginState = { inProcess: false, cancelCallback: null };
             onLoginComplete(error, mobileServiceToken, client, callback);
-        });
+        },
+        provider,
+        client.applicationUrl
+    );
 
     if (login._loginState.inProcess && platformResult && platformResult.cancelCallback) {
         login._loginState.cancelCallback = platformResult.cancelCallback;

--- a/sdk/src/Platform/web/index.js
+++ b/sdk/src/Platform/web/index.js
@@ -148,7 +148,7 @@ exports.getSdkInfo = function () {
     };
 };
 
-exports.login = function (startUri, endUri, callback) {
+exports.login = function (startUri, endUri, callback, providerName, appUrl) {
     // Force logins to go over HTTPS because the runtime is hardcoded to redirect
     // the server flow back to HTTPS, and we need the origin to match.
     var findProtocol = /^[a-z]+:/,
@@ -158,7 +158,7 @@ exports.login = function (startUri, endUri, callback) {
         endUri = endUri.replace(findProtocol, requiredProtocol);
     }
 
-    return getBestProvider(knownLoginUis).login(startUri, endUri, callback);
+    return getBestProvider(knownLoginUis).login(startUri, endUri, callback, providerName, appUrl);
 };
 
 exports.toJson = function (value) {


### PR DESCRIPTION
Google no longer supports InAppBrowser plugin to perform OAuth requests within it. To fix it InAppBrowser was replaced by native calls to MobileService.login which uses reliable azure-mobile-apps-android-client
implementation of login.

This PR connected with these [one](https://github.com/Azure/azure-mobile-apps-cordova-client/pull/50) which includes android implementation for cordova client.